### PR TITLE
support config profiles

### DIFF
--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -12,7 +12,7 @@ func TestWriteConfigToFileDirExists(t *testing.T) {
 	defer os.RemoveAll(tempDirName)
 	os.MkdirAll(tempDirName+string(filepath.Separator)+Config_dir, 0700)
 
-	writeConfigToFile(tempDirName, "server", "user", "password", "output")
+	writeConfigToFile(tempDirName, "server", "user", "password", "output", "default")
 
 	validateConfigContent(tempDirName, t)
 }
@@ -21,7 +21,7 @@ func TestWriteConfigToFileDirNotExists(t *testing.T) {
 	tempDirName, _ := ioutil.TempDir("", "configwritetest")
 	defer os.RemoveAll(tempDirName)
 
-	writeConfigToFile(tempDirName, "server", "user", "password", "output")
+	writeConfigToFile(tempDirName, "server", "user", "password", "output", "default")
 
 	validateConfigContent(tempDirName, t)
 }
@@ -29,7 +29,7 @@ func TestWriteConfigToFileDirNotExists(t *testing.T) {
 func validateConfigContent(tempDirName string, t *testing.T) {
 	content, _ := ioutil.ReadFile(tempDirName + string(filepath.Separator) + Config_dir + string(filepath.Separator) + Config_file)
 
-	expected := "username: user\npassword: password\nserver: server\noutput: output\n"
+	expected := "default:\n  username: user\n  password: password\n  server: server\n  output: output\n"
 	if string(content) != expected {
 		t.Errorf("content not match %s == %s", expected, string(content))
 	}
@@ -41,9 +41,9 @@ func TestReadConfig(t *testing.T) {
 
 	os.MkdirAll(tempDirName+string(filepath.Separator)+Config_dir, 0700)
 	password := "§±!@#$%^&*()_+-=[]{};'\\:\"/.,?><`~"
-	ioutil.WriteFile(tempDirName+string(filepath.Separator)+Config_dir+string(filepath.Separator)+Config_file, []byte("username: user\npassword: "+password+"\nserver: server\noutput: output\n"), 0700)
+	ioutil.WriteFile(tempDirName+string(filepath.Separator)+Config_dir+string(filepath.Separator)+Config_file, []byte("default:\n  username: user\n  password: "+password+"\n  server: server\n  output: output\n"), 0700)
 
-	config, err := ReadConfig(tempDirName)
+	config, err := ReadConfig(tempDirName, "default")
 
 	if err != nil {
 		t.Errorf("unable to read file: %s", err.Error())

--- a/cli/hdc_flags.go
+++ b/cli/hdc_flags.go
@@ -41,6 +41,14 @@ var (
 			EnvVar: "CB_OUT_FORMAT",
 		},
 	}
+	FlProfile = StringFlag{
+		RequiredFlag: OPTIONAL,
+		StringFlag: cli.StringFlag{
+			Name:   "profile",
+			Usage:  "selects a config profile to use",
+			EnvVar: "CB_PROFILE",
+		},
+	}
 	FlForce = BoolFlag{
 		RequiredFlag: OPTIONAL,
 		BoolFlag: cli.BoolFlag{
@@ -356,7 +364,7 @@ func (fb *FlagBuilder) AddFlags(flags ...cli.Flag) *FlagBuilder {
 }
 
 func (fb *FlagBuilder) AddAuthenticationFlags() *FlagBuilder {
-	for _, f := range []cli.Flag{FlServer, FlUsername, FlPassword} {
+	for _, f := range []cli.Flag{FlServer, FlUsername, FlPassword, FlProfile} {
 		fb.flags = append(fb.flags, f)
 	}
 	return fb

--- a/main.go
+++ b/main.go
@@ -28,12 +28,18 @@ func ConfigRead(c *cli.Context) error {
 	username := c.String(cb.FlUsername.Name)
 	password := c.String(cb.FlPassword.Name)
 	output := c.String(cb.FlOutput.Name)
+	profile := c.String(cb.FlProfile.Name)
+	if len(profile) == 0 {
+		profile = "default"
+	}
 
-	config, err := cb.ReadConfig(cb.GetHomeDirectory())
-	if err == nil {
-		if len(output) == 0 {
-			c.Set(cb.FlOutput.Name, config.Output)
-		}
+	config, err := cb.ReadConfig(cb.GetHomeDirectory(), profile)
+	if err != nil {
+		utils.LogErrorAndExit(err)
+	}
+
+	if len(output) == 0 {
+		c.Set(cb.FlOutput.Name, config.Output)
 	}
 
 	if len(server) == 0 || len(username) == 0 || len(password) == 0 {
@@ -102,10 +108,10 @@ func main() {
 			Description: fmt.Sprintf("it will save the provided server address and credential "+
 				"to %s/%s/%s", cb.GetHomeDirectory(), cb.Config_dir, cb.Config_file),
 			Usage:  "configure the server address and credentials used to communicate with this server",
-			Flags:  cb.NewFlagBuilder().AddFlags(cb.FlServerRequired, cb.FlUsernameRequired, cb.FlPassword).AddOutputFlag().Build(),
+			Flags:  cb.NewFlagBuilder().AddFlags(cb.FlServerRequired, cb.FlUsernameRequired, cb.FlPassword, cb.FlProfile).AddOutputFlag().Build(),
 			Action: cb.Configure,
 			BashComplete: func(c *cli.Context) {
-				for _, f := range cb.NewFlagBuilder().AddFlags(cb.FlServerRequired, cb.FlUsernameRequired, cb.FlPassword).AddOutputFlag().Build() {
+				for _, f := range cb.NewFlagBuilder().AddFlags(cb.FlServerRequired, cb.FlUsernameRequired, cb.FlPassword, cb.FlProfile).AddOutputFlag().Build() {
 					printFlagCompletion(f)
 				}
 			},


### PR DESCRIPTION
example config file:
```
default:
  username: <username>
  server: <address>
staging:
  username: <username>
  server: <address>
```

notes:
- the configure command can be used without the profile switch, in this case the "default" section is written to the config file. If --profile is set, the config is written to the file under that name.
- if configure is called multiple times the config file is appended instead of recreated
- if no --profile switch is provided for the cli commands, then the "default" profile is used.
- the CB_PROFILE environment variable can be used instead of --profile
