### PR TITLE
BUG-116180: strategy selection while assigning roles

### DIFF
--- a/dataplane/cmd/tenant.go
+++ b/dataplane/cmd/tenant.go
@@ -61,18 +61,6 @@ func init() {
 					}
 				},
 			},
-			{
-				Name:   "disable",
-				Usage:  "disable a tenant",
-				Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCaasTenantName).AddAuthenticationFlags().AddOutputFlag().Build(),
-				Before: cf.CheckConfigAndCommandFlagsDP,
-				Action: tenant.DisableTenant,
-				BashComplete: func(c *cli.Context) {
-					for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCaasTenantName).AddAuthenticationFlags().AddOutputFlag().Build() {
-						fl.PrintFlagCompletion(f)
-					}
-				},
-			},
 		},
 	})
 }

--- a/dataplane/cmd/user.go
+++ b/dataplane/cmd/user.go
@@ -50,7 +50,7 @@ func init() {
 			},
 			{
 				Name:  "add",
-				Usage: "provide information about a user",
+				Usage: "add new roles to a user",
 				Subcommands: []cli.Command{
 					{
 						Name:   "roles-by-ids",
@@ -66,12 +66,12 @@ func init() {
 					},
 					{
 						Name:   "roles",
-						Usage:  "Add roles to a user",
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlUserName, fl.FlRoleNames).AddAuthenticationFlags().Build(),
+						Usage:  "Add roles to a user by name",
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlUserName, fl.FlRoleNames, fl.FlCaasStrategyName).AddAuthenticationFlags().Build(),
 						Before: cf.CheckConfigAndCommandFlagsDP,
 						Action: user.AssignRolesToUserByName,
 						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlUserID, fl.FlRoleNames).AddAuthenticationFlags().Build() {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlUserID, fl.FlRoleNames, fl.FlCaasStrategyName).AddAuthenticationFlags().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},
@@ -80,11 +80,11 @@ func init() {
 			},
 			{
 				Name:  "remove",
-				Usage: "provide information about a user",
+				Usage: "remove roles from user",
 				Subcommands: []cli.Command{
 					{
 						Name:   "roles-by-ids",
-						Usage:  "revoke roles from a user",
+						Usage:  "revoke roles from a user by ids",
 						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlUserID, fl.FlRolesIDs).AddAuthenticationFlags().Build(),
 						Before: cf.CheckConfigAndCommandFlagsDP,
 						Action: user.RevokeRoles,
@@ -96,12 +96,12 @@ func init() {
 					},
 					{
 						Name:   "roles",
-						Usage:  "revoke roles from a user",
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlUserName, fl.FlRoleNames).AddAuthenticationFlags().Build(),
+						Usage:  "revoke roles from a user by name",
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlUserName, fl.FlRoleNames, fl.FlCaasStrategyName).AddAuthenticationFlags().Build(),
 						Before: cf.CheckConfigAndCommandFlagsDP,
 						Action: user.RevokeRolesFromUserByName,
 						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlUserName, fl.FlRoleNames).AddAuthenticationFlags().Build() {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlUserName, fl.FlRoleNames, fl.FlCaasStrategyName).AddAuthenticationFlags().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},

--- a/dataplane/flags/flags.go
+++ b/dataplane/flags/flags.go
@@ -869,7 +869,7 @@ var (
 	FlCaasStrategyName = StringFlag{
 		RequiredFlag: OPTIONAL,
 		StringFlag: cli.StringFlag{
-			Name:  "name",
+			Name:  "strategy-name",
 			Usage: "name of strategy",
 		},
 	}

--- a/dataplane/tenant/tenant.go
+++ b/dataplane/tenant/tenant.go
@@ -135,6 +135,7 @@ func SendPasswordResetEMail(c *cli.Context) {
 
 }
 
+//DisableTenant : Disable a tenant
 func DisableTenant(c *cli.Context) {
 	log.Infof("[RegisterTenant] Disable a tenant")
 	output := utils.Output{Format: c.String(fl.FlOutputOptional.Name)}


### PR DESCRIPTION
Allow to select users from strategy local. This is required since their can be 2 strategies active at same time.
Removed disable tenant command. Will be added later when we have enable logic build