### PR TITLE
pstree like command structure

### DIFF
--- a/cmd/command_tree.go
+++ b/cmd/command_tree.go
@@ -2,40 +2,134 @@ package cmd
 
 import (
 	"fmt"
-
 	dpcmd "github.com/hortonworks/cb-cli/dataplane/cmd"
+	fl "github.com/hortonworks/cb-cli/dataplane/flags"
 	"github.com/urfave/cli"
 )
 
-const indent = "    "
+const (
+	newLine      = "\n"
+	emptySpace   = "    "
+	middleItem   = "├── "
+	continueItem = "│   "
+	lastItem     = "└── "
+)
 
 func init() {
 	AppCommands = append(AppCommands, cli.Command{
 		Name:   "command-tree",
 		Usage:  "prints the command tree",
 		Action: printCommandTree,
+		Flags:  fl.NewFlagBuilder().AddFlags(fl.FlShowUsage).Build(),
+		BashComplete: func(c *cli.Context) {
+			for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlShowUsage).Build() {
+				fl.PrintFlagCompletion(f)
+			}
+		},
 		Hidden: true,
 	})
 }
 
 func printCommandTree(c *cli.Context) {
-	printCommandTreeDepth(c, dpcmd.DataPlaneCommands, 0)
+	tree := New(c.App.Name)
+	buildTree(dpcmd.DataPlaneCommands, tree, c.Bool(fl.FlShowUsage.Name))
+	fmt.Println(tree.Print())
 }
 
-func printCommandTreeDepth(c *cli.Context, commands []cli.Command, depth int) error {
+func buildTree(commands []cli.Command, tree Tree, showUsage bool) {
 	for _, command := range commands {
-		fmt.Println(spaces(depth), "⌞", command.Name, " - ", command.Usage)
+		name := command.Name
+		if showUsage {
+			name += " - " + command.Usage
+		}
+		subTree := tree.Add(name)
 		if command.Subcommands != nil && len(command.Subcommands) > 0 {
-			printCommandTreeDepth(c, command.Subcommands, depth+1)
+			buildTree(command.Subcommands, subTree, showUsage)
 		}
 	}
-	return nil
 }
 
-func spaces(depth int) string {
-	result := ""
-	for i := 0; i < depth; i++ {
-		result = result + indent
+type (
+	tree struct {
+		text  string
+		items []Tree
+	}
+
+	Tree interface {
+		Add(text string) Tree
+		Items() []Tree
+		Text() string
+		Print() string
+	}
+
+	printer struct {
+	}
+
+	Printer interface {
+		Print(Tree) string
+	}
+)
+
+func New(text string) Tree {
+	return &tree{
+		text:  text,
+		items: []Tree{},
+	}
+}
+
+func (t *tree) Add(text string) Tree {
+	n := New(text)
+	t.items = append(t.items, n)
+	return n
+}
+
+func (t *tree) Text() string {
+	return t.text
+}
+
+func (t *tree) Items() []Tree {
+	return t.items
+}
+
+func (t *tree) Print() string {
+	return newPrinter().Print(t)
+}
+
+func newPrinter() Printer {
+	return &printer{}
+}
+
+func (p *printer) Print(t Tree) string {
+	return t.Text() + newLine + p.printItems(t.Items(), []bool{})
+}
+
+func (p *printer) printText(text string, spaces []bool, last bool) string {
+	var result string
+	for _, space := range spaces {
+		if space {
+			result += emptySpace
+		} else {
+			result += continueItem
+		}
+	}
+
+	indicator := middleItem
+	if last {
+		indicator = lastItem
+	}
+
+	return result + indicator + text + newLine
+}
+
+func (p *printer) printItems(t []Tree, spaces []bool) string {
+	var result string
+	for i, f := range t {
+		last := i == len(t)-1
+		result += p.printText(f.Text(), spaces, last)
+		if len(f.Items()) > 0 {
+			spacesChild := append(spaces, last)
+			result += p.printItems(f.Items(), spacesChild)
+		}
 	}
 	return result
 }

--- a/dataplane/flags/flags.go
+++ b/dataplane/flags/flags.go
@@ -619,20 +619,6 @@ var (
 			Usage: "id of the image",
 		},
 	}
-	FlKey = StringFlag{
-		RequiredFlag: REQUIRED,
-		StringFlag: cli.StringFlag{
-			Name:  "key",
-			Usage: "key of the tag",
-		},
-	}
-	FlValue = StringFlag{
-		RequiredFlag: REQUIRED,
-		StringFlag: cli.StringFlag{
-			Name:  "value",
-			Usage: "value of the tag",
-		},
-	}
 	FlProxyHost = StringFlag{
 		RequiredFlag: REQUIRED,
 		StringFlag: cli.StringFlag{
@@ -908,13 +894,6 @@ var (
 			Usage: "comma seperated values of role names",
 		},
 	}
-	FlCaasUsers = StringFlag{
-		RequiredFlag: REQUIRED,
-		StringFlag: cli.StringFlag{
-			Name:  "user-names",
-			Usage: "comma seperated values of user names",
-		},
-	}
 	FlVersion = StringFlag{
 		RequiredFlag: REQUIRED,
 		StringFlag: cli.StringFlag{
@@ -1151,6 +1130,13 @@ var (
 		StringFlag: cli.StringFlag{
 			Name:  "admin",
 			Usage: "kerberos admin",
+		},
+	}
+	FlShowUsage = BoolFlag{
+		RequiredFlag: OPTIONAL,
+		BoolFlag: cli.BoolFlag{
+			Name:  "show-usage",
+			Usage: "shows the command usage",
 		},
 	}
 )


### PR DESCRIPTION
There is no new-year without coding. Refine `command-tree` to be pstree like:
```
dp
├── audit
│   ├── list
│   │   ├── blueprint
│   │   ├── cluster
│   │   ├── credential
│   │   ├── database
│   │   ├── imagecatalog
│   │   ├── ldap
│   │   └── recipe
│   └── describe
├── blueprint
│   ├── create
│   │   ├── from-url
│   │   └── from-file
│   ├── delete
│   ├── describe
│   └── list
├── cloud
│   ├── availability-zones
│   ├── instances
│   ├── regions
│   └── volumes
│       ├── aws
│       ├── azure
│       └── gcp
├── cluster
│   ├── change-ambari-password
│   ├── change-image
│   ├── create
│   ├── delete
│   ├── describe
│   ├── generate-template
│   │   ├── yarn
│   │   ├── aws
│   │   │   ├── new-network
│   │   │   ├── existing-network
│   │   │   └── existing-subnet
│   │   ├── azure
│   │   │   ├── new-network
│   │   │   └── existing-subnet
│   │   ├── gcp
│   │   │   ├── new-network
│   │   │   ├── existing-network
│   │   │   ├── existing-subnet
│   │   │   ├── legacy-network
│   │   │   └── shared-network
│   │   └── openstack
│   │       ├── new-network
│   │       ├── existing-network
│   │       └── existing-subnet
│   ├── generate-reinstall-template
│   ├── generate-attached-cluster-template
│   ├── list
│   ├── reinstall
│   ├── repair
│   │   ├── host-groups
│   │   └── nodes
│   ├── retry
│   ├── scale
│   ├── start
│   ├── stop
│   ├── sync
│   └── maintenance-mode
│       ├── enable
│       ├── disable
│       ├── validate
│       ├── hdp
│       ├── hdf
│       ├── ambari
│       └── generate-template-json
│           ├── hdp
│           ├── hdf
│           └── ambari
...
```