### PR TITLE
BUG-116859 cb-cli: rds test by param: database type not evaluated cor…

### DIFF
--- a/cloudbreak/cmd/database.go
+++ b/cloudbreak/cmd/database.go
@@ -121,11 +121,11 @@ func init() {
 					{
 						Name:   "by-params",
 						Usage:  "test database connection parameters",
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlRdsUserName, fl.FlRdsPassword, fl.FlRdsURL, fl.FlRdsType).AddAuthenticationFlags().Build(),
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlRdsUserName, fl.FlRdsPassword, fl.FlRdsURL).AddAuthenticationFlags().Build(),
 						Before: cf.CheckConfigAndCommandFlags,
 						Action: rds.TestRdsByParams,
 						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlRdsUserName, fl.FlRdsPassword, fl.FlRdsURL, fl.FlRdsType).AddAuthenticationFlags().Build() {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlRdsUserName, fl.FlRdsPassword, fl.FlRdsURL).AddAuthenticationFlags().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},

--- a/cloudbreak/rds/rds.go
+++ b/cloudbreak/rds/rds.go
@@ -61,8 +61,7 @@ func TestRdsByParams(c *cli.Context) {
 		c.Int64(fl.FlWorkspaceOptional.Name),
 		c.String(fl.FlRdsUserName.Name),
 		c.String(fl.FlRdsPassword.Name),
-		c.String(fl.FlRdsURL.Name),
-		c.String(fl.FlRdsType.Name))
+		c.String(fl.FlRdsURL.Name))
 }
 
 func testRdsByNameImpl(client rdsClient, workspaceID int64, name string) {
@@ -80,7 +79,7 @@ func testRdsByNameImpl(client rdsClient, workspaceID int64, name string) {
 	}
 }
 
-func testRdsByParamsImpl(client rdsClient, workspaceID int64, username string, password string, URL string, rdsType string) {
+func testRdsByParamsImpl(client rdsClient, workspaceID int64, username string, password string, URL string) {
 	defer utils.TimeTrack(time.Now(), "test database configuration by parameters")
 	rdsRequest := &model.RdsTestRequest{
 		RdsConfig: &model.RdsConfig{
@@ -88,7 +87,7 @@ func testRdsByParamsImpl(client rdsClient, workspaceID int64, username string, p
 			ConnectionUserName: &username,
 			ConnectionPassword: &password,
 			ConnectionURL:      &URL,
-			Type:               &rdsType,
+			Type:               &(&types.S{S: "testtype"}).S,
 		},
 	}
 	log.Infof("[testRdsByParamsImpl] sending test database configuration by parameters request")


### PR DESCRIPTION
…rectly

Type is not necessary for testing the database.