### PR TITLE
CB-603 Determine active branch for checkouted commit

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,9 @@
 GIT_FIRST_PARENT ?= $(shell git describe --tags --first-parent | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]-*([a-z]+\.)*[0-9]+).*/\1/p')
 GIT_LATEST_TAG ?= $(shell git describe --tags | grep -Eo "^[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+\.[0-9]*")
-GIT_ACTIVE_BRANCH ?= $(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD | sed -e 's|origin/||g')
+GIT_ACTIVE_BRANCH ?= $(shell git rev-parse HEAD)
 DOCKER_IP ?= $(shell echo $(DOCKER_HOST) | awk -F/ '{print $$3}' | sed 's/:.*//')
-BLUEPRINT_URL ?= https://rawgit.com/hortonworks/cb-cli/$(GIT_ACTIVE_BRANCH)/tests/blueprints/test.bp
-RECIPE_URL ?= https://rawgit.com/hortonworks/cb-cli/$(GIT_ACTIVE_BRANCH)/tests/recipes/echo.sh
+BLUEPRINT_URL ?= https://raw.githubusercontent.com/hortonworks/cb-cli/$(GIT_ACTIVE_BRANCH)/tests/blueprints/test.bp
+RECIPE_URL ?= https://raw.githubusercontent.com/hortonworks/cb-cli/$(GIT_ACTIVE_BRANCH)/tests/recipes/echo.sh
 
 ifeq ($(DOCKER_IP),)
     DOCKER_IP=127.0.0.1


### PR DESCRIPTION
The Jenkins checks out code to be built by commit. The previous script returned "HEAD" in this case, which resulted in the urls pointing to master, where the blueprint folder was renamed.