### PR TITLE
update rc-2.9 to built on go 1.12 with vendoring enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ format:
 	@gofmt -w ${GOFILES_NOVENDOR}
 
 vet:
-	GO111MODULE=on go vet -shadow ./...
+	GO111MODULE=on go vet -mod=vendor ./...
 
 test:
-	GO111MODULE=on go test -timeout 30s -race ./...
+	GO111MODULE=on go test -mod=vendor -timeout 30s -race ./...
 
 errcheck:
 #	Module support is not on master yet: https://github.com/kisielk/errcheck/issues/152#issuecomment-415945206
@@ -53,19 +53,19 @@ build-version: errcheck format vet test build-darwin-version build-linux-version
 
 build-docker:
 	@#USER_NS='-u $(shell id -u $(whoami)):$(shell id -g $(whoami))'
-	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e VERSION=${VERSION} -e GO111MODULE=on golang:1.11 make deps-errcheck build
+	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e VERSION=${VERSION} -e GO111MODULE=on golang:1.12 make build
 
 build-darwin:
-	GOOS=darwin GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS_NOVER} -o build/Darwin/${BINARY} main.go
+	GOOS=darwin GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -a ${LDFLAGS_NOVER} -o build/Darwin/${BINARY} main.go
 
 dev-debug-darwin:
-	GOOS=darwin GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS_NOVER} -o /usr/local/bin/${BINARY} main.go
+	GOOS=darwin GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -a ${LDFLAGS_NOVER} -o /usr/local/bin/${BINARY} main.go
 
 build-linux:
-	GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS_NOVER} -o build/Linux/${BINARY} main.go
+	GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -a ${LDFLAGS_NOVER} -o build/Linux/${BINARY} main.go
 
 build-windows:
-	GOOS=windows GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS_NOVER} -o build/Windows/${BINARY}.exe main.go
+	GOOS=windows GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -a ${LDFLAGS_NOVER} -o build/Windows/${BINARY}.exe main.go
 
 build-darwin-version:
 	GOOS=darwin GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS} -o build/Darwin/${BINARY} main.go
@@ -121,11 +121,11 @@ release-version: build-version
 
 release-docker:
 	@USER_NS='-u $(shell id -u $(whoami)):$(shell id -g $(whoami))'
-	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e VERSION=${VERSION} -e GITHUB_ACCESS_TOKEN=${GITHUB_TOKEN} -e GO111MODULE=on golang:1.11 bash -c "make deps && make release"
+	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e VERSION=${VERSION} -e GITHUB_ACCESS_TOKEN=${GITHUB_TOKEN} -e GO111MODULE=on golang:1.12 bash -c "make deps && make release"
 
 release-docker-version:
 	@USER_NS='-u $(shell id -u $(whoami)):$(shell id -g $(whoami))'
-	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e VERSION=${VERSION} -e GITHUB_ACCESS_TOKEN=${GITHUB_TOKEN} -e GO111MODULE=on golang:1.11 bash -c "make deps && make release-version"
+	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e VERSION=${VERSION} -e GITHUB_ACCESS_TOKEN=${GITHUB_TOKEN} -e GO111MODULE=on golang:1.12 bash -c "make deps && make release-version"
 
 upload_s3:
 	ls -1 release | xargs -I@ aws s3 cp release/@ s3://cb-cli/@ --acl public-read
@@ -146,7 +146,7 @@ e2e-test:
 	make -C tests e2e-test
 
 mod-tidy:
-	@docker run --rm -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e GO111MODULE=on golang:1.11 make _mod-tidy
+	@docker run --rm -v "${PWD}":/go/src/github.com/hortonworks/cb-cli -w /go/src/github.com/hortonworks/cb-cli -e GO111MODULE=on golang:1.12 make _mod-tidy
 
 _mod-tidy:
 	go mod tidy -v

--- a/cloudbreak/credential/credential.go
+++ b/cloudbreak/credential/credential.go
@@ -267,7 +267,14 @@ func DescribeCredential(c *cli.Context) {
 	}
 
 	cred := resp.Payload
-	output.Write(append(common.CloudResourceHeader, "ID"), &credentialOutDescribe{&common.CloudResourceOut{*cred.Name, *cred.Description, *cred.CloudPlatform}, strconv.FormatInt(cred.ID, 10)})
+	output.Write(append(common.CloudResourceHeader, "ID"), &credentialOutDescribe{
+		&common.CloudResourceOut{
+			Name:          *cred.Name,
+			Description:   *cred.Description,
+			CloudPlatform: *cred.CloudPlatform,
+		},
+		strconv.FormatInt(cred.ID, 10)},
+	)
 }
 
 func DeleteCredential(c *cli.Context) {
@@ -305,7 +312,11 @@ func listCredentialsImpl(client listCredentialsByWorkspaceClient, workspaceID in
 
 	tableRows := []utils.Row{}
 	for _, cred := range credResp.Payload {
-		tableRows = append(tableRows, &common.CloudResourceOut{*cred.Name, *cred.Description, *cred.CloudPlatform})
+		tableRows = append(tableRows, &common.CloudResourceOut{
+			Name:          *cred.Name,
+			Description:   *cred.Description,
+			CloudPlatform: *cred.CloudPlatform},
+		)
 	}
 
 	writer(common.CloudResourceHeader, tableRows)

--- a/cloudbreak/stack/stack.go
+++ b/cloudbreak/stack/stack.go
@@ -123,7 +123,11 @@ func assembleStackRequest(c *cli.Context) *model.StackV2Request {
 
 func convertViewResponseToStack(s *model.StackViewResponse) *stackOut {
 	return &stackOut{
-		common.CloudResourceOut{*s.Name, utils.SafeClusterViewDescriptionConvert(s), utils.SafeCredentialViewCloudPlatformConvert(s)},
+		common.CloudResourceOut{
+			Name:          *s.Name,
+			Description:   utils.SafeClusterViewDescriptionConvert(s),
+			CloudPlatform: utils.SafeCredentialViewCloudPlatformConvert(s),
+		},
 		s.Status,
 		utils.SafeClusterViewStatusConvert(s),
 	}
@@ -131,7 +135,11 @@ func convertViewResponseToStack(s *model.StackViewResponse) *stackOut {
 
 func convertResponseToStack(s *model.StackResponse) *stackOut {
 	return &stackOut{
-		common.CloudResourceOut{*s.Name, utils.SafeClusterDescriptionConvert(s), utils.SafeCredentialCloudPlatformConvert(s)},
+		common.CloudResourceOut{
+			Name:          *s.Name,
+			Description:   utils.SafeClusterDescriptionConvert(s),
+			CloudPlatform: utils.SafeCredentialCloudPlatformConvert(s),
+		},
 		s.Status,
 		utils.SafeClusterStatusConvert(s),
 	}

--- a/cloudbreak/stack/stack_functions_test.go
+++ b/cloudbreak/stack/stack_functions_test.go
@@ -90,7 +90,8 @@ type getStackNotFoundClient struct {
 
 func (c getStackNotFoundClient) GetStackInWorkspace(*v3_workspace_id_stacks.GetStackInWorkspaceParams) (*v3_workspace_id_stacks.GetStackInWorkspaceOK, error) {
 	return nil, &utils.RESTError{
-		nil, 403,
+		Response: nil,
+		Code:     403,
 	}
 }
 


### PR DESCRIPTION
occasionally builds fail due to various dependencies so it's a good time to upgrade and use the saved vendor folder instead