### PR TITLE
CB-597. Parse out CDH version from CDH blueprints.

### DIFF
--- a/dataplane/clusterdefinition/clusterdefinition.go
+++ b/dataplane/clusterdefinition/clusterdefinition.go
@@ -192,7 +192,11 @@ func convertResponseWithContentAndIDToClusterDefinition(bp *model.ClusterDefinit
 		clusterDefinitionsNode := blueprints.(map[string]interface{})
 		stackName = clusterDefinitionsNode["stack_name"].(string)
 		stackVersion = clusterDefinitionsNode["stack_version"].(string)
+	} else if cdhVersion, ok := jsonRoot["cdhVersion"]; ok {
+		stackName = "CDH"
+		stackVersion = cdhVersion.(string)
 	}
+
 	return &clusterDefinitionOutJsonDescribe{
 		clusterDefinitionOut: &clusterDefinitionOut{
 			Name:           *bp.Name,


### PR DESCRIPTION
This allows the CLI  to properly display information from CDH blueprints.