### PR TITLE
[CB-1281] dp cli reports itself as cb in error messages

### DIFF
--- a/completion/zsh_autocomplete
+++ b/completion/zsh_autocomplete
@@ -1,4 +1,4 @@
 autoload -U compinit && compinit
 autoload -U bashcompinit && bashcompinit
 
-eval "$(cb completion)"
+eval "$(dp completion)"

--- a/dataplane/cmd/cluster.go
+++ b/dataplane/cmd/cluster.go
@@ -57,7 +57,7 @@ func init() {
 			{
 				Name:        "create",
 				Usage:       "creates a new cluster",
-				Description: `use 'cb cluster generate-template' for cluster request JSON generation`,
+				Description: `use 'dp cluster generate-template' for cluster request JSON generation`,
 				Flags:       fl.NewFlagBuilder().AddResourceFlagsWithOptionalName().AddFlags(fl.FlInputJson, fl.FlAmbariUserOptional, fl.FlAmbariPasswordOptional, fl.FlWaitOptional).AddAuthenticationFlags().Build(),
 				Before:      cf.CheckConfigAndCommandFlags,
 				Action:      stack.CreateStack,

--- a/dataplane/config/config.go
+++ b/dataplane/config/config.go
@@ -77,7 +77,7 @@ func CheckConfigAndCommandFlagsDP(c *cli.Context) error {
 func validateContext(c *cli.Context, flagsTocheck []fl.StringFlag) {
 	for _, f := range flagsTocheck {
 		if len(c.String(f.Name)) == 0 {
-			log.Error(fmt.Sprintf("configuration is not set, see: cb configure --help or provide the following flags: %v",
+			log.Error(fmt.Sprintf("configuration is not set, see: dp configure --help or provide the following flags: %v",
 				[]string{"--" + f.Name}))
 			os.Exit(1)
 		}

--- a/dataplane/flags/flags.go
+++ b/dataplane/flags/flags.go
@@ -694,7 +694,7 @@ var (
 		RequiredFlag: OPTIONAL,
 		BoolFlag: cli.BoolFlag{
 			Name:  "not-validated",
-			Usage: "[DEPRECATED] has no effect, use 'cb database test ...' command instead",
+			Usage: "[DEPRECATED] has no effect, use 'dp database test ...' command instead",
 		},
 	}
 	FlKubernetesConfigFile = StringFlag{

--- a/tests/scripts/test_run.sh
+++ b/tests/scripts/test_run.sh
@@ -24,7 +24,7 @@ echo "CLI Tests: "$CLI_TEST_FILES
 curl --verbose --show-error --location --insecure -C - https://s3.amazonaws.com/dp-cli/dp-cli_"${TARGET_CBD_VERSION}"_$(uname)_x86_64.tgz | tar -xvz --directory /usr/local/bin
 
 token=$(wget --continue --no-check-certificate $BASE_URL/oidc/authorize?username=$USERNAME_CLI\&tenant=$CBD_TENANT -O -)
-echo $token | cb configure --server $BASE_URL --workspace $USERNAME_CLI
+echo $token | dp configure --server $BASE_URL --workspace $USERNAME_CLI
 
 mkdir -p tmp/aruba
 rspec -f RspecJunitFormatter -o test-result.xml -f h $CLI_TEST_FILES | tee test-result.html | ruby -n spec/common/integration_formatter.rb


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace some leftover `cb` references, eg.:

```
$ dp database create mysql
...
   --not-validated            [DEPRECATED] has no effect, use 'cb database test ...' command instead
```

## How was this patch tested?

Built locally and verified the output of the same commands, eg.:

```
$ build/$(uname)/dp database create mysql
...
   --not-validated            [DEPRECATED] has no effect, use 'dp database test ...' command instead
```