### PR TITLE
Generic description for --file

### DIFF
--- a/dataplane/cmd/recipe.go
+++ b/dataplane/cmd/recipe.go
@@ -14,7 +14,7 @@ func init() {
 		Subcommands: []cli.Command{
 			{
 				Name:  "create",
-				Usage: "adds a new recipe from a file or from a URL",
+				Usage: "adds a new recipe from a file",
 				Subcommands: []cli.Command{
 					{
 						Name:   "from-file",

--- a/dataplane/flags/flags.go
+++ b/dataplane/flags/flags.go
@@ -245,14 +245,14 @@ var (
 		RequiredFlag: REQUIRED,
 		StringFlag: cli.StringFlag{
 			Name:  "file",
-			Usage: "location of the blueprint JSON file",
+			Usage: "location of the input JSON file",
 		},
 	}
 	FlURL = StringFlag{
 		RequiredFlag: REQUIRED,
 		StringFlag: cli.StringFlag{
 			Name:  "url",
-			Usage: "URL location of the JSON file",
+			Usage: "URL location of the input JSON file",
 		},
 	}
 	FlBlueprintName = StringFlag{


### PR DESCRIPTION
*  Make description of `--file` more generic, as it currently references "blueprint" even for recipes.
* Recipe can only be created from file, not URL.