### PR TITLE
Fix "Missing clusterRequest.ambariRequest node" error

### DIFF
--- a/dataplane/stack/stack.go
+++ b/dataplane/stack/stack.go
@@ -111,7 +111,7 @@ func assembleStackRequest(c *cli.Context) *model.StackV4Request {
 	ambariUser := c.String(fl.FlAmbariUserOptional.Name)
 	ambariPassword := c.String(fl.FlAmbariPasswordOptional.Name)
 	if len(ambariUser) != 0 || len(ambariPassword) != 0 {
-		if req.Cluster != nil && req.Cluster.Ambari != nil {
+		if req.Cluster != nil {
 			if len(ambariUser) != 0 {
 				req.Cluster.UserName = &ambariUser
 			}
@@ -119,7 +119,7 @@ func assembleStackRequest(c *cli.Context) *model.StackV4Request {
 				req.Cluster.Password = &ambariPassword
 			}
 		} else {
-			commonutils.LogErrorMessageAndExit("Missing clusterRequest.ambariRequest node in JSON")
+			commonutils.LogErrorMessageAndExit("Missing cluster node in JSON")
 		}
 	}
 	return &req


### PR DESCRIPTION
The following error occurs when creating CM cluster and passing admin username/password as command-line parameters:

```
$ dp cluster create --cli-input-json def.json --name cluster1 --input-json-param-user admin --input-json-param-password *****
ERROR: Missing clusterRequest.ambariRequest node in JSON
```

Since the username/password are at the cluster-level, the check for Ambari node seems unnecessary.