### PR TITLE
CB-1317. Remove leftover debug

### DIFF
--- a/dataplane/env/environment.go
+++ b/dataplane/env/environment.go
@@ -220,8 +220,6 @@ func DescribeEnvironment(c *cli.Context) {
 		utils.LogErrorAndExit(err)
 	}
 	env := resp.Payload
-	fmt.Printf("%+v\n", env)
-	fmt.Printf("%+v\n", env.Regions.DisplayNames)
 	if output.Format != "table" && output.Format != "yaml" {
 		output.Write(append(EnvironmentHeader, "Network"), convertResponseToJsonOutput(env))
 	} else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

There appears to be some leftover debug in `env describe` output, so it's not valid JSON:

```
$ dp env describe --name ganeshk-omg
&{CloudPlatform:AWS Creator:crn:altus:iam:us-west-1:...
map[us-west-2:US West (Oregon)]
{
  "Name": "ganeshk-omg",
  "CloudPlatform": "AWS",
  "Status": "CORRUPTED",
  ...
}
```

## How was this patch tested?

```
$ ./build/Darwin/dp env describe --name ganeshk-omg
{
  "Name": "ganeshk-omg",
  "CloudPlatform": "AWS",
  "Status": "CORRUPTED",
  ...
}
```