### PR TITLE
CB-2902 Environment response should contain ssh-keypair name

### DIFF
--- a/dataplane/env/environment.go
+++ b/dataplane/env/environment.go
@@ -39,9 +39,10 @@ type environmentOutTableDescribe struct {
 
 type environmentOutJsonDescribe struct {
 	*environment
-	ProxyConfigs []string                           `json:"ProxyConfigs" yaml:"ProxyConfigs"`
-	Network      model.EnvironmentNetworkV1Response `json:"Network" yaml:"Network"`
-	Telemetry    model.TelemetryResponse            `json:"Telemetry" yaml:"Telemetry"`
+	ProxyConfigs   []string                                  `json:"ProxyConfigs" yaml:"ProxyConfigs"`
+	Network        model.EnvironmentNetworkV1Response        `json:"Network" yaml:"Network"`
+	Telemetry      model.TelemetryResponse                   `json:"Telemetry" yaml:"Telemetry"`
+	Authentication model.EnvironmentAuthenticationV1Response `json:"Authentication" yaml:"Authentication"`
 }
 
 type environmentListJsonDescribe struct {
@@ -280,7 +281,7 @@ func DescribeEnvironment(c *cli.Context) {
 	}
 	env := resp.Payload
 	if output.Format != "table" && output.Format != "yaml" {
-		output.Write(append(EnvironmentHeader, "Network", "Telemetry"), convertResponseToJsonOutput(env))
+		output.Write(append(EnvironmentHeader, "Network", "Telemetry", "Authentication"), convertResponseToJsonOutput(env))
 	} else {
 		output.Write(append(EnvironmentHeader), convertResponseToTableOutput(env))
 	}
@@ -381,6 +382,9 @@ func convertResponseToJsonOutput(env *model.DetailedEnvironmentV1Response) *envi
 	}
 	if env.Telemetry != nil {
 		result.Telemetry = *env.Telemetry
+	}
+	if env.Authentication != nil {
+		result.Authentication = *env.Authentication
 	}
 	return result
 }


### PR DESCRIPTION
The new response (excerpt):
`dp env describe --name gtopolyai-ycloud-env1`
`{
  "Name": "gtopolyai-ycloud-env1",
  "Authentication": {
    "loginUserName": "cloudbreak",
    "publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCl9n1RqkCVZlgtNyxG6wwY7WIgXPq+YyRf/i7y0hpvVo+KLcQEfUe6vK34ZKMp9nmsBhsaSAaJSL3jWYSKlyAt2iEyNuORaNXQS5yiHGHtvCOTKQCB1X2UTqAoE+DI8U00IMApDzibcJU32qX4d5DkCq70A4/nec3KVJnfST5FTzRsN+hf0X/1e59PIdq280IqVU2Nw5BdNUOMcsHYug59i1EkccGbHyBwwtzur+eKF9OsRS7L0fSc9hka266mQZnIE3YH8KFuN9SySaR9x8YGeWSr1D3s4HV2/6pN4vBWJ1huF6q/Y3F4PvlmtHcFY3fzzHuE9J6BVhpvhZn6jJ98CC7sTrWI4VUB/wLiwGMnlstMeBkyDSJ1V9keX8DGXhMy7JRKQz6OBjLRSDBd4es3PFNyk8LCc7sQsm84U340CXVHgxLWge0J8xsmT/b8xrdq8L8p8hsZ4IlIPi+UCQLYSGcNtpp3G06+26gxCqbBvBFiEEq9pNzRjp2RezVp/UE0bq/SU8GjdggqTW6GH0yF/1VervNcV9vRaiQLkU4m5XyJTXt9THAli//RbqggHyDTFqngKZJi+thVCZlriaU7uVEIWs/3yc9dJNGHM/hGqbG2RRjgSh6U7wJkgFBWcxSYi3ZaWAMwmqitwYuIOONTxGwPsBfx831FIPP8lk1jSw== gerely01@gmail.com"
  }
}`