### PR TITLE
CB-1845 Begin expanding redbeams CLI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ FREEIPA_PORT = $(shell echo \${PORT})
 ifeq ($(FREEIPA_PORT),)
         FREEIPA_PORT = 8090
 endif
-CB_IP = $(shell echo \${IP})
+REDBEAMS_IP = $(shell echo \${IP})
 ifeq ($(REDBEAMS_IP),)
         REDBEAMS_IP = localhost
 endif
@@ -38,7 +38,6 @@ REDBEAMS_PORT = $(shell echo \${PORT})
 ifeq ($(REDBEAMS_PORT),)
         REDBEAMS_PORT = 8087
 endif
-
 ifeq ($(ENVIRONMENT_IP),)
         ENVIRONMENT_IP = localhost
 endif

--- a/dataplane/cmd/redbeams.go
+++ b/dataplane/cmd/redbeams.go
@@ -15,18 +15,18 @@ import (
 func init() {
 	DataPlaneCommands = append(DataPlaneCommands, cli.Command{
 		Name:  "redbeams",
-		Usage: "manage RBDMS instances and databases",
+		Usage: "manage relational databases and database servers",
 		Subcommands: []cli.Command{
 			{
 				Name:  "dbserver",
-				Usage: "manage redbeams instances",
+				Usage: "manage redbeams database servers",
 				Subcommands: []cli.Command{
 					{
 						Name:   "list",
-						Usage:  "list all RBDMS instances",
+						Usage:  "list all database servers",
 						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
 						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
-						Action: redbeams.ListRBDMSInstances,
+						Action: redbeams.ListDatabaseServers,
 						BashComplete: func(c *cli.Context) {
 							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
 								fl.PrintFlagCompletion(f)
@@ -34,11 +34,71 @@ func init() {
 						},
 					},
 					{
+						Name:   "describe",
+						Usage:  "describe a database server, getting it by CRN",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.GetDatabaseServer,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "describe-by-name",
+						Usage:  "describe a database server, getting it by name",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.GetDatabaseServerByName,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "get-status",
+						Usage:  "get the status of a database server by CRN",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.GetDatabaseServerStatus,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "get-status-by-name",
+						Usage:  "get the status of a database server by name",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.GetDatabaseServerStatusByName,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "terminate",
+						Usage:  "terminate a managed database server",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.TerminateManagedDatabaseServer,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
 						Name:   "delete",
-						Usage:  "deletes an RBDMS instance",
+						Usage:  "delete a registered database server",
 						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
 						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().Build(),
-						Action: redbeams.DeleteRBDMSInstance,
+						Action: redbeams.DeleteDatabaseServer,
 						BashComplete: func(c *cli.Context) {
 							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().Build() {
 								fl.PrintFlagCompletion(f)

--- a/dataplane/oauth/oauth_client.go
+++ b/dataplane/oauth/oauth_client.go
@@ -109,22 +109,22 @@ func NewEnvironmentClient(address string, apiKeyID, privateKey string) *Environm
 	return &Environment{Environment: environmentclient.New(transport, strfmt.Default)}
 }
 
-func NewRedbeamsClientFromContext(c *cli.Context) *Redbeams {
-	return NewRedbeamsClientFrom(c.String(fl.FlServerOptional.Name), c.String(fl.FlApiKeyIDOptional.Name), c.String(fl.FlPrivateKeyOptional.Name))
-}
-
-func NewRedbeamsClientFrom(address string, apiKeyID, privateKey string) *Redbeams {
-	u.CheckServerAddress(address)
-	var transport *utils.Transport
-	const baseAPIPath string = "/redbeams/api"
-	transport = apikeyauth.GetAPIKeyAuthTransport(address, baseAPIPath, apiKeyID, privateKey)
-	return &Redbeams{Redbeams: redbeamsclient.New(transport, strfmt.Default)}
-}
-
 func NewEnvironmentActorCrnHTTPClient(address string, actorCrn string) *Environment {
 	u.CheckServerAddress(address)
 	var transport *utils.Transport
 	const baseAPIPath string = "/environmentservice/api"
 	transport = apikeyauth.GetActorCrnAuthTransport(address, baseAPIPath, actorCrn)
 	return &Environment{Environment: environmentclient.New(transport, strfmt.Default)}
+}
+
+func NewRedbeamsClientFromContext(c *cli.Context) *Redbeams {
+	return NewRedbeamsClient(c.String(fl.FlServerOptional.Name), c.String(fl.FlApiKeyIDOptional.Name), c.String(fl.FlPrivateKeyOptional.Name))
+}
+
+func NewRedbeamsClient(address string, apiKeyID, privateKey string) *Redbeams {
+	u.CheckServerAddress(address)
+	var transport *utils.Transport
+	const baseAPIPath string = "/redbeams/api"
+	transport = apikeyauth.GetAPIKeyAuthTransport(address, baseAPIPath, apiKeyID, privateKey)
+	return &Redbeams{Redbeams: redbeamsclient.New(transport, strfmt.Default)}
 }

--- a/dataplane/redbeams/redbeams.go
+++ b/dataplane/redbeams/redbeams.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	"github.com/hortonworks/cb-cli/dataplane/api-redbeams/client/database_servers"
+	"github.com/hortonworks/cb-cli/dataplane/api-redbeams/model"
 	fl "github.com/hortonworks/cb-cli/dataplane/flags"
 	"github.com/hortonworks/cb-cli/dataplane/oauth"
-	"github.com/hortonworks/dp-cli-common/utils"
 	commonutils "github.com/hortonworks/dp-cli-common/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -14,54 +14,200 @@ import (
 
 type ClientRedbeams oauth.Redbeams
 
-var listHeader = []string{"Name", "Crn", "EnvironmentCrn", "Status"}
+var serverListHeader = []string{"Name", "Description", "Crn", "EnvironmentCrn", "Status", "ResourceStatus", "DatabaseVendor", "Host", "Port"}
 
-type redbeamsDetails struct {
+type serverDetails struct {
+	Name           string `json:"Name" yaml:"Name"`
+	Description    string `json:"Description" yaml:"Description"`
+	CRN            string `json:"CRN" yaml:"CRN"`
+	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
+	Status         string `json:"Status" yaml:"Status"`
+	StatusReason   string `json:"StatusReason" yaml:"StatusReason"`
+	ResourceStatus string `json:"ResourceStatus" yaml:"ResourceStatus"`
+	DatabaseVendor string `json:"DatabaseVendor" yaml:"DatabaseVendor"`
+	Host           string `json:"Host" yaml:"Host"`
+	Port           int32  `json:"Port" yaml:"Port"`
+	CreationDate   int64  `json:"CreationDate" yaml:"CreationDate"`
+}
+
+func (server *serverDetails) DataAsStringArray() []string {
+	return []string{server.Name, server.Description, server.CRN, server.EnvironmentCrn, server.Status, server.DatabaseVendor, server.Host, string(server.Port)}
+}
+
+func NewDetailsFromResponse(r *model.DatabaseServerV4Response) *serverDetails {
+	details := &serverDetails{
+		Name:           *r.Name,
+		CRN:            r.Crn,
+		EnvironmentCrn: *r.EnvironmentCrn,
+		Status:         r.Status,
+		StatusReason:   r.StatusReason,
+		ResourceStatus: r.ResourceStatus,
+		CreationDate:   r.CreationDate,
+	}
+
+	// ternary operator, where art thou?
+	if r.Description != nil {
+		details.Description = *r.Description
+	}
+	if r.DatabaseVendor != nil {
+		details.DatabaseVendor = *r.DatabaseVendor
+	}
+	if r.Host != nil {
+		details.Host = *r.Host
+	}
+	if r.Port != nil {
+		details.Port = *r.Port
+	}
+
+	return details
+}
+
+var statusListHeader = []string{"Name", "Crn", "EnvironmentCrn", "Status"}
+
+type serverStatusDetails struct {
 	Name           string `json:"Name" yaml:"Name"`
 	CRN            string `json:"CRN" yaml:"CRN"`
 	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
 	Status         string `json:"Status" yaml:"Status"`
 }
 
-func (redbeams *redbeamsDetails) DataAsStringArray() []string {
-	return []string{redbeams.Name, redbeams.CRN, redbeams.EnvironmentCrn, redbeams.Status}
+func (status *serverStatusDetails) DataAsStringArray() []string {
+	return []string{status.Name, status.CRN, status.EnvironmentCrn, status.Status}
 }
 
-func ListRBDMSInstances(c *cli.Context) {
-	defer utils.TimeTrack(time.Now(), "List Rbdms instances in environment")
+func NewDetailsFromStatusResponse(r *model.DatabaseServerStatusV4Response) *serverStatusDetails {
+	details := &serverStatusDetails{
+		Name:           *r.Name,
+		CRN:            *r.ResourceCrn,
+		EnvironmentCrn: *r.EnvironmentCrn,
+		Status:         *r.Status,
+	}
+
+	return details
+}
+
+func ListDatabaseServers(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "List database servers in environment")
 	envCrn := c.String(fl.FlEnvironmentCrn.Name)
 	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
 
+	log.Infof("[ListDBServers] Listing database servers in environment: %s", envCrn)
 	resp, err := redbeamsDbServerClient.ListDatabaseServers(database_servers.NewListDatabaseServersParams().WithEnvironmentCrn(envCrn))
 	if err != nil {
 		commonutils.LogErrorAndExit(err)
 	}
 
-	log.Infof("[ListRBDMS] RBDMS list in environment: %s", envCrn)
 	output := commonutils.Output{Format: c.String(fl.FlOutputOptional.Name)}
 
 	var tableRows []commonutils.Row
 
 	for _, response := range resp.Payload.Responses {
-		row := &redbeamsDetails{
-			Name:           *response.Name,
-			CRN:            response.Crn,
-			EnvironmentCrn: *response.EnvironmentCrn,
-			Status:         response.Status,
-		}
+		row := NewDetailsFromResponse(response)
 		tableRows = append(tableRows, row)
 	}
-	output.WriteList(listHeader, tableRows)
+	output.WriteList(serverListHeader, tableRows)
 }
 
-func DeleteRBDMSInstance(c *cli.Context) {
-	defer commonutils.TimeTrack(time.Now(), "delete RBDMS instance")
+func GetDatabaseServer(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "Get a database server by CRN")
 	crn := c.String(fl.FlCrn.Name)
-
 	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
+
+	log.Infof("[GetDBServer] Getting database server with CRN: %s", crn)
+	resp, err := redbeamsDbServerClient.GetDatabaseServerByCrn(database_servers.NewGetDatabaseServerByCrnParams().WithCrn(crn))
+	if err != nil {
+		commonutils.LogErrorAndExit(err)
+	}
+
+	server := resp.Payload
+	output := commonutils.Output{Format: c.String(fl.FlOutputOptional.Name)}
+	row := NewDetailsFromResponse(server)
+	output.Write(serverListHeader, row)
+}
+
+func GetDatabaseServerByName(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "Get a database server by name")
+	envCrn := c.String(fl.FlEnvironmentCrn.Name)
+	name := c.String(fl.FlName.Name)
+	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
+
+	log.Infof("[GetDBServerByName] Getting database server with name: %s", name)
+	resp, err := redbeamsDbServerClient.GetDatabaseServerByName(database_servers.NewGetDatabaseServerByNameParams().WithEnvironmentCrn(envCrn).WithName(name))
+	if err != nil {
+		commonutils.LogErrorAndExit(err)
+	}
+
+	server := resp.Payload
+	output := commonutils.Output{Format: c.String(fl.FlOutputOptional.Name)}
+	row := NewDetailsFromResponse(server)
+	output.Write(serverListHeader, row)
+}
+
+func GetDatabaseServerStatus(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "Get the status of a database server by CRN")
+	crn := c.String(fl.FlCrn.Name)
+	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
+
+	log.Infof("[GetDBServerStatus] Getting status for database server with CRN: %s", crn)
+	resp, err := redbeamsDbServerClient.GetDatabaseServerStatusByCrn(database_servers.NewGetDatabaseServerStatusByCrnParams().WithCrn(crn))
+	if err != nil {
+		commonutils.LogErrorAndExit(err)
+	}
+
+	status := resp.Payload
+	output := commonutils.Output{Format: c.String(fl.FlOutputOptional.Name)}
+	row := NewDetailsFromStatusResponse(status)
+	output.Write(statusListHeader, row)
+}
+
+func GetDatabaseServerStatusByName(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "Get the status of a database server by name")
+	envCrn := c.String(fl.FlEnvironmentCrn.Name)
+	name := c.String(fl.FlName.Name)
+	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
+
+	log.Infof("[GetDBServerStatusByName] Getting status for database server with name: %s", name)
+	resp, err := redbeamsDbServerClient.GetDatabaseServerStatusByName(database_servers.NewGetDatabaseServerStatusByNameParams().WithEnvironmentCrn(envCrn).WithName(name))
+	if err != nil {
+		commonutils.LogErrorAndExit(err)
+	}
+
+	status := resp.Payload
+	output := commonutils.Output{Format: c.String(fl.FlOutputOptional.Name)}
+	row := NewDetailsFromStatusResponse(status)
+	output.Write(statusListHeader, row)
+}
+
+func TerminateManagedDatabaseServer(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "Terminate a managed database server")
+	crn := c.String(fl.FlCrn.Name)
+	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
+
+	log.Infof("[TerminateDBServer] Terminating database server with CRN: %s", crn)
+	resp, err := redbeamsDbServerClient.TerminateManagedDatabaseServer(database_servers.NewTerminateManagedDatabaseServerParams().WithCrn(crn))
+	if err != nil {
+		commonutils.LogErrorAndExit(err)
+	}
+
+	outcome := resp.Payload
+	output := commonutils.Output{Format: c.String(fl.FlOutputOptional.Name)}
+	output.Write(statusListHeader, &serverStatusDetails{
+		Name:           *outcome.Name,
+		CRN:            *outcome.ResourceCrn,
+		EnvironmentCrn: *outcome.EnvironmentCrn,
+		Status:         outcome.Status,
+	})
+}
+
+func DeleteDatabaseServer(c *cli.Context) {
+	defer commonutils.TimeTrack(time.Now(), "Delete a registered database server")
+	crn := c.String(fl.FlCrn.Name)
+	redbeamsDbServerClient := ClientRedbeams(*oauth.NewRedbeamsClientFromContext(c)).Redbeams.DatabaseServers
+
+	log.Infof("[DeleteDBServer] Deleting database server with CRN: %s", crn)
 	result, err := redbeamsDbServerClient.DeleteDatabaseServerByCrn(database_servers.NewDeleteDatabaseServerByCrnParams().WithCrn(crn))
 	if err != nil {
-		utils.LogErrorAndExit(err)
+		commonutils.LogErrorAndExit(err)
 	}
-	log.Infof("[deleteRBDMSInstance] RBDMS instance deleted in with name: %s Details: %s", crn, result)
+	log.Infof("[DeleteDBServer] Deleted database server with CRN: %s Details: %s", crn, result)
 }


### PR DESCRIPTION
The following new redbeams dbserver commands are implemented in the CLI:

- describe
- describe-by-name
- get-status
- get-status-by-name
- terminate

The existing list and delete commands are updated and improved as well.