### PR TITLE
CB-2981 added databaseServerCrn to SDX response

### DIFF
--- a/dataplane/api-sdx/model/sdx_cluster_detail_response.go
+++ b/dataplane/api-sdx/model/sdx_cluster_detail_response.go
@@ -29,6 +29,9 @@ type SdxClusterDetailResponse struct {
 	// crn
 	Crn string `json:"crn,omitempty"`
 
+	// database server crn
+	DatabaseServerCrn string `json:"databaseServerCrn,omitempty"`
+
 	// environment crn
 	EnvironmentCrn string `json:"environmentCrn,omitempty"`
 

--- a/dataplane/api-sdx/model/sdx_cluster_response.go
+++ b/dataplane/api-sdx/model/sdx_cluster_response.go
@@ -29,6 +29,9 @@ type SdxClusterResponse struct {
 	// crn
 	Crn string `json:"crn,omitempty"`
 
+	// database server crn
+	DatabaseServerCrn string `json:"databaseServerCrn,omitempty"`
+
 	// environment crn
 	EnvironmentCrn string `json:"environmentCrn,omitempty"`
 

--- a/dataplane/sdx/sdx.go
+++ b/dataplane/sdx/sdx.go
@@ -21,17 +21,18 @@ import (
 var sdxClusterHeader = []string{"Crn", "Name", "EnvironmentName", "EnvironmentCrn", "StackCrn", "Status", "StatusReason"}
 
 type sdxClusterOutput struct {
-	Crn            string `json:"Crn" yaml:"Crn"`
-	Name           string `json:"Name" yaml:"Name"`
-	Environment    string `json:"environmentName" yaml:"environmentName"`
-	EnvironmentCrn string `json:"environmentCrn" yaml:"environmentCrn"`
-	StackCrn       string `json:"stackCrn" yaml:"stackCrn"`
-	Status         string `json:"Status" yaml:"Status"`
-	StatusReason   string `json:"StatusReason" yaml:"StatusReason"`
+	Crn               string `json:"Crn" yaml:"Crn"`
+	Name              string `json:"Name" yaml:"Name"`
+	Environment       string `json:"environmentName" yaml:"environmentName"`
+	EnvironmentCrn    string `json:"environmentCrn" yaml:"environmentCrn"`
+	StackCrn          string `json:"stackCrn" yaml:"stackCrn"`
+	DatabaseServerCrn string `json:"databaseServerCrn" yaml:"databaseServerCrn"`
+	Status            string `json:"Status" yaml:"Status"`
+	StatusReason      string `json:"StatusReason" yaml:"StatusReason"`
 }
 
 func (r *sdxClusterOutput) DataAsStringArray() []string {
-	return []string{r.Crn, r.Name, r.Environment, r.EnvironmentCrn, r.StackCrn, r.Status, r.StatusReason}
+	return []string{r.Crn, r.Name, r.Environment, r.EnvironmentCrn, r.StackCrn, r.DatabaseServerCrn, r.Status, r.StatusReason}
 }
 
 type ClientSdx oauth.Sdx
@@ -189,6 +190,7 @@ func listSdxClusterImpl(client clientSdx, envName string, writer func([]string, 
 			sdxCluster.EnvironmentName,
 			sdxCluster.EnvironmentCrn,
 			sdxCluster.StackCrn,
+			sdxCluster.DatabaseServerCrn,
 			sdxCluster.Status,
 			sdxCluster.StatusReason})
 	}
@@ -213,6 +215,7 @@ func DescribeSdx(c *cli.Context) {
 		sdxCluster.EnvironmentName,
 		sdxCluster.EnvironmentCrn,
 		sdxCluster.StackCrn,
+		sdxCluster.DatabaseServerCrn,
 		sdxCluster.Status,
 		sdxCluster.StatusReason})
 	log.Infof("[DescribeSdx] Describe a particular SDX cluster")

--- a/dataplane/sdx/sdx_test.go
+++ b/dataplane/sdx/sdx_test.go
@@ -15,13 +15,14 @@ type mockListSdxClustersClient struct {
 func (*mockListSdxClustersClient) ListSdx(params *sdx.ListSdxParams) (*sdx.ListSdxOK, error) {
 	resp := []*sdxModel.SdxClusterResponse{
 		{
-			Crn:             "crn:altus:sdx:us-west-1:tenantName:sdxcluster:b8a64902-7765-4ddd-a4f3-df81ae585e10",
-			Name:            "ExampleClusterName",
-			EnvironmentName: "ExampleEnvironmentName",
-			EnvironmentCrn:  "crn:altus:environment:us-west-1:tenantName:sdxcluster:aaa64902-1111-4567-123-df81ae585e10",
-			StackCrn:        "crn:altus:environment:us-west-1:tenantName:stack:aaa64902-1111-4567-123-df81ae585e10",
-			Status:          "AVAILABLE",
-			StatusReason:    "Reason",
+			Crn:               "crn:altus:sdx:us-west-1:tenantName:sdxcluster:b8a64902-7765-4ddd-a4f3-df81ae585e10",
+			Name:              "ExampleClusterName",
+			EnvironmentName:   "ExampleEnvironmentName",
+			EnvironmentCrn:    "crn:altus:environment:us-west-1:tenantName:sdxcluster:aaa64902-1111-4567-123-df81ae585e10",
+			StackCrn:          "crn:altus:environment:us-west-1:tenantName:stack:aaa64902-1111-4567-123-df81ae585e10",
+			DatabaseServerCrn: "crn:altus:environment:us-west-1:tenantName:databaseserver:aaa64902-1111-4567-123-df81ae585e10",
+			Status:            "AVAILABLE",
+			StatusReason:      "Reason",
 		},
 	}
 	return &sdx.ListSdxOK{Payload: resp}, nil
@@ -36,7 +37,7 @@ func TestListSdx(t *testing.T) {
 		t.Fatalf("row number doesn't match 1 == %d", len(rows))
 	}
 	for _, r := range rows {
-		expected := "crn:altus:sdx:us-west-1:tenantName:sdxcluster:b8a64902-7765-4ddd-a4f3-df81ae585e10 ExampleClusterName ExampleEnvironmentName crn:altus:environment:us-west-1:tenantName:sdxcluster:aaa64902-1111-4567-123-df81ae585e10 crn:altus:environment:us-west-1:tenantName:stack:aaa64902-1111-4567-123-df81ae585e10 AVAILABLE Reason"
+		expected := "crn:altus:sdx:us-west-1:tenantName:sdxcluster:b8a64902-7765-4ddd-a4f3-df81ae585e10 ExampleClusterName ExampleEnvironmentName crn:altus:environment:us-west-1:tenantName:sdxcluster:aaa64902-1111-4567-123-df81ae585e10 crn:altus:environment:us-west-1:tenantName:stack:aaa64902-1111-4567-123-df81ae585e10 crn:altus:environment:us-west-1:tenantName:databaseserver:aaa64902-1111-4567-123-df81ae585e10 AVAILABLE Reason"
 		if strings.Join(r.DataAsStringArray(), " ") != expected {
 			t.Errorf("row data not match %s == %s", expected, strings.Join(r.DataAsStringArray(), " "))
 		}


### PR DESCRIPTION
Response now looks like this:
```
  {
    "Crn": "crn:altus:sdx:us-west-1:default:sdxcluster:a680311f-0388-4556-9fd3-7bf53664277e",
    "Name": "lnardai-repair-backup",
    "environmentName": "lnardai-repair-test",
    "environmentCrn": "crn:altus:environments:us-west-1:default:environment:55d53183-1c23-4765-8e2e-721eaaa057b5",
    "stackCrn": "crn:altus:cloudbreak:us-west-1:default:stack:5b68c86e-3708-4433-9928-0a941dddbf40",
    "databaseServerCrn": "crn:altus:redbeams:us-west-1:default:databaseServer:250af3ad-b731-492b-8e03-2d00489284c8",
    "Status": "EXTERNAL_DATABASE_DELETION_IN_PROGRESS",
    "StatusReason": ""
  }
```