### PR TITLE
CB-1845 Complete redbeams dbserver commands

### DIFF
--- a/dataplane/cmd/redbeams.go
+++ b/dataplane/cmd/redbeams.go
@@ -34,49 +34,51 @@ func init() {
 						},
 					},
 					{
-						Name:   "describe",
-						Usage:  "describe a database server, getting it by CRN",
-						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Name:        "describe",
+						Usage:       "describe a database server",
+						Description: "To specify a database server, either provide its CRN, or both its environment CRN and name.",
+						Before: func(c *cli.Context) error {
+							err := cf.CheckConfigAndCommandFlagsWithoutWorkspace(c)
+							if err != nil {
+								return err
+							}
+							return cf.CheckResourceAddressingFlags(c)
+						},
+						Flags:  fl.NewFlagBuilder().AddResourceAddressingFlags().AddAuthenticationFlags().AddOutputFlag().Build(),
 						Action: redbeams.GetDatabaseServer,
 						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+							for _, f := range fl.NewFlagBuilder().AddResourceAddressingFlags().AddAuthenticationFlags().AddOutputFlag().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},
 					},
 					{
-						Name:   "describe-by-name",
-						Usage:  "describe a database server, getting it by name",
-						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build(),
-						Action: redbeams.GetDatabaseServerByName,
-						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build() {
-								fl.PrintFlagCompletion(f)
+						Name:        "get-status",
+						Usage:       "get the status of a database server (stack)",
+						Description: "To specify a database server, either provide its CRN, or both its environment CRN and name.",
+						Before: func(c *cli.Context) error {
+							err := cf.CheckConfigAndCommandFlagsWithoutWorkspace(c)
+							if err != nil {
+								return err
 							}
+							return cf.CheckResourceAddressingFlags(c)
 						},
-					},
-					{
-						Name:   "get-status",
-						Usage:  "get the status of a database server by CRN",
-						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Flags:  fl.NewFlagBuilder().AddResourceAddressingFlags().AddAuthenticationFlags().AddOutputFlag().Build(),
 						Action: redbeams.GetDatabaseServerStatus,
 						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+							for _, f := range fl.NewFlagBuilder().AddResourceAddressingFlags().AddAuthenticationFlags().AddOutputFlag().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},
 					},
 					{
-						Name:   "get-status-by-name",
-						Usage:  "get the status of a database server by name",
+						Name:   "create",
+						Usage:  "create a managed database server",
 						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
-						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build(),
-						Action: redbeams.GetDatabaseServerStatusByName,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlDatabaseServerCreationFile).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.CreateManagedDatabaseServer,
 						BashComplete: func(c *cli.Context) {
-							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build() {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlDatabaseServerCreationFile).AddAuthenticationFlags().AddOutputFlag().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},
@@ -89,6 +91,18 @@ func init() {
 						Action: redbeams.TerminateManagedDatabaseServer,
 						BashComplete: func(c *cli.Context) {
 							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "register",
+						Usage:  "register a database server",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlDatabaseServerRegistrationFile).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.RegisterDatabaseServer,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlDatabaseServerRegistrationFile).AddAuthenticationFlags().AddOutputFlag().Build() {
 								fl.PrintFlagCompletion(f)
 							}
 						},

--- a/dataplane/config/config.go
+++ b/dataplane/config/config.go
@@ -235,3 +235,19 @@ func readConfigToList(configPath string, configList *ConfigList) error {
 	}
 	return nil
 }
+
+func CheckResourceAddressingFlags(c *cli.Context) error {
+	crnPresent := len(c.String(fl.FlCrnOptional.GetName())) != 0
+	envCrnPresent := len(c.String(fl.FlEnvironmentCrnOptional.GetName())) != 0
+	namePresent := len(c.String(fl.FlName.GetName())) != 0
+
+	if crnPresent && !envCrnPresent && !namePresent {
+		return nil
+	}
+
+	if !crnPresent && envCrnPresent && namePresent {
+		return nil
+	}
+
+	return errors.New("Invalid resource addressing: either supply a resource CRN, or an environment CRN and resource name")
+}

--- a/dataplane/flags/flags.go
+++ b/dataplane/flags/flags.go
@@ -101,6 +101,13 @@ var (
 			Usage: "name of resource",
 		},
 	}
+	FlCrnOptional = StringFlag{
+		RequiredFlag: OPTIONAL,
+		StringFlag: cli.StringFlag{
+			Name:  "crn",
+			Usage: "crn of the resource",
+		},
+	}
 	FlClusterToUpgrade = StringFlag{
 		RequiredFlag: REQUIRED,
 		StringFlag: cli.StringFlag{
@@ -992,6 +999,13 @@ var (
 			Usage: "crn of an environment",
 		},
 	}
+	FlEnvironmentCrnOptional = StringFlag{
+		RequiredFlag: OPTIONAL,
+		StringFlag: cli.StringFlag{
+			Name:  "env-crn",
+			Usage: "crn of an environment",
+		},
+	}
 	FlEnvironmentNameOptional = StringFlag{
 		RequiredFlag: OPTIONAL,
 		StringFlag: cli.StringFlag{
@@ -1287,6 +1301,20 @@ var (
 			Usage: "creates and external database server on the cloud provider",
 		},
 	}
+	FlDatabaseServerCreationFile = StringFlag{
+		RequiredFlag: REQUIRED,
+		StringFlag: cli.StringFlag{
+			Name:  "database-server-creation-file",
+			Usage: "location of the JSON file for database server creation",
+		},
+	}
+	FlDatabaseServerRegistrationFile = StringFlag{
+		RequiredFlag: REQUIRED,
+		StringFlag: cli.StringFlag{
+			Name:  "database-server-registration-file",
+			Usage: "location of the JSON file for database server registration",
+		},
+	}
 )
 
 type RequiredFlag struct {
@@ -1451,6 +1479,13 @@ func (fb *FlagBuilder) AddResourceDefaultFlags() *FlagBuilder {
 
 func (fb *FlagBuilder) AddResourceFlagsWithOptionalName() *FlagBuilder {
 	for _, f := range []cli.Flag{FlNameOptional, FlDescriptionOptional} {
+		fb.flags = append(fb.flags, f)
+	}
+	return fb
+}
+
+func (fb *FlagBuilder) AddResourceAddressingFlags() *FlagBuilder {
+	for _, f := range []cli.Flag{FlCrnOptional, FlNameOptional, FlEnvironmentCrnOptional} {
 		fb.flags = append(fb.flags, f)
 	}
 	return fb


### PR DESCRIPTION
The following new commands are available for redbeams dbserver:

* create, for allocating new service-managed database servers
* register, for registering existing user-managed database servers

In addition:

The formerly separate describe / describe-by-name and get-status /
get-status-by-name redbeams operations are merged into single commands.
For either of the new commands, a valid call is one that passes either
only a CRN, or a pair of environment CRN and name. The command
implementations call the appropriate redbeams API endpoint depending
on the provided options.

New optional CRN flags are introduced, as well as a new function for
checking on valid "resource addressing" option combinations, in order
to enable this change.