### PR TITLE
CB-1857 Add redbeams db commands

### DIFF
--- a/dataplane/cmd/redbeams.go
+++ b/dataplane/cmd/redbeams.go
@@ -121,6 +121,72 @@ func init() {
 					},
 				},
 			},
+			{
+				Name:  "db",
+				Usage: "manage redbeams databases",
+				Subcommands: []cli.Command{
+					{
+						Name:   "list",
+						Usage:  "list all databases",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.ListDatabases,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "describe",
+						Usage:  "describe a database",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.GetDatabase,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "create",
+						Usage:  "create a database",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlDatabaseCreationFile).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.CreateDatabase,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlDatabaseCreationFile).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "register",
+						Usage:  "register a database",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlDatabaseRegistrationFile).AddAuthenticationFlags().AddOutputFlag().Build(),
+						Action: redbeams.RegisterDatabase,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlDatabaseRegistrationFile).AddAuthenticationFlags().AddOutputFlag().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+					{
+						Name:   "delete",
+						Usage:  "delete a database",
+						Before: cf.CheckConfigAndCommandFlagsWithoutWorkspace,
+						Flags:  fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().Build(),
+						Action: redbeams.DeleteDatabase,
+						BashComplete: func(c *cli.Context) {
+							for _, f := range fl.NewFlagBuilder().AddFlags(fl.FlEnvironmentCrn, fl.FlName).AddAuthenticationFlags().Build() {
+								fl.PrintFlagCompletion(f)
+							}
+						},
+					},
+				},
+			},
 		},
 	})
 }

--- a/dataplane/flags/flags.go
+++ b/dataplane/flags/flags.go
@@ -1315,6 +1315,20 @@ var (
 			Usage: "location of the JSON file for database server registration",
 		},
 	}
+	FlDatabaseCreationFile = StringFlag{
+		RequiredFlag: REQUIRED,
+		StringFlag: cli.StringFlag{
+			Name:  "database-creation-file",
+			Usage: "location of the JSON file for database creation",
+		},
+	}
+	FlDatabaseRegistrationFile = StringFlag{
+		RequiredFlag: REQUIRED,
+		StringFlag: cli.StringFlag{
+			Name:  "database-registration-file",
+			Usage: "location of the JSON file for database registration",
+		},
+	}
 )
 
 type RequiredFlag struct {


### PR DESCRIPTION
The following new commands are available for redbeams db:

* list
* describe
* create, for creating new service-managed databases
* register, for registering existing user-managed databases
* delete, for deleting either service-managed or user-managed databases