### PR TITLE
CB-3000. Validation for SDX always fails if no provided cloud storage…

### DIFF
--- a/dataplane/sdx/sdx.go
+++ b/dataplane/sdx/sdx.go
@@ -3,9 +3,10 @@ package sdx
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hortonworks/cb-cli/dataplane/env"
 	"os"
 	"time"
+
+	"github.com/hortonworks/cb-cli/dataplane/env"
 
 	"github.com/hortonworks/cb-cli/dataplane/api-sdx/client/internalsdx"
 	"github.com/hortonworks/cb-cli/dataplane/api-sdx/client/sdx"
@@ -85,18 +86,24 @@ func CreateSdx(c *cli.Context) {
 }
 
 func createSdx(clusterShape string, envName string, c *cli.Context, name string, cloudStorageBaseLocation string, instanceProfile string, withExternalDatabase bool) {
-	s3CloudStorage := &sdxModel.S3CloudStorageV1Parameters{
-		InstanceProfile: &instanceProfile,
-	}
+	var cloudStorage *sdxModel.SdxCloudStorageRequest
+	var s3CloudStorage *sdxModel.S3CloudStorageV1Parameters
 
-	cloudStorage := &sdxModel.SdxCloudStorageRequest{
-		Adls:           nil,
-		AdlsGen2:       nil,
-		BaseLocation:   cloudStorageBaseLocation,
-		FileSystemType: "S3",
-		Gcs:            nil,
-		S3:             s3CloudStorage,
-		Wasb:           nil,
+	if len(instanceProfile) > 0 {
+		s3CloudStorage = &sdxModel.S3CloudStorageV1Parameters{
+			InstanceProfile: &instanceProfile,
+		}
+	}
+	if len(cloudStorageBaseLocation) > 0 {
+		cloudStorage = &sdxModel.SdxCloudStorageRequest{
+			Adls:           nil,
+			AdlsGen2:       nil,
+			BaseLocation:   cloudStorageBaseLocation,
+			FileSystemType: "S3",
+			Gcs:            nil,
+			S3:             s3CloudStorage,
+			Wasb:           nil,
+		}
 	}
 
 	externalDatabase := &sdxModel.SdxDatabaseRequest{


### PR DESCRIPTION
… configs

let cloud storage request data to be nil if cloud storage details is not provided.

as those data are missing, cli will send an empty request, that will cause sdx cluster creation with cli will always fail