### PR TITLE
CB-3069 uppercase slayer

### DIFF
--- a/dataplane/audit/audit.go
+++ b/dataplane/audit/audit.go
@@ -18,7 +18,7 @@ import (
 var auditListHeader = []string{"AuditID", "EventType", "TimeStamp", "ResourceId", "ResourceName", "ResourceType", "UserName", "Status", "Duration"}
 
 type auditListOut struct {
-	Audit *model.AuditEventV4Response `json:"Audit" yaml:"Audit"`
+	Audit *model.AuditEventV4Response `json:"audit" yaml:"audit"`
 }
 
 func (a *auditListOut) DataAsStringArray() []string {
@@ -33,7 +33,7 @@ func convertToDateTimeString(t int64) string {
 var auditHeader = []string{"Audit"}
 
 type auditOut struct {
-	Audit *model.AuditEventV4Response `json:"Audit" yaml:"Audit"`
+	Audit *model.AuditEventV4Response `json:"audit" yaml:"audit"`
 }
 
 type auditClient interface {

--- a/dataplane/blueprint/blueprint.go
+++ b/dataplane/blueprint/blueprint.go
@@ -21,23 +21,23 @@ import (
 var blueprintHeader = []string{"Name", "Description", "StackName", "StackVersion", "Hostgroup Count", "Tags"}
 
 type blueprintOut struct {
-	Name           string `json:"Name" yaml:"Name"`
-	Description    string `json:"Description" yaml:"Description"`
-	StackName      string `json:"StackName" yaml:"StackName"`
-	StackVersion   string `json:"StackVersion" yaml:"StackVersion"`
-	HostgroupCount string `json:"HostgroupCount" yaml:"HostgroupCount"`
-	Tags           string `json:"Tags" yaml:"Tags"`
+	Name           string `json:"name" yaml:"name"`
+	Description    string `json:"description" yaml:"description"`
+	StackName      string `json:"stackName" yaml:"stackName"`
+	StackVersion   string `json:"stackVersion" yaml:"stackVersion"`
+	HostgroupCount string `json:"hostgroupCount" yaml:"hostgroupCount"`
+	Tags           string `json:"tags" yaml:"tags"`
 }
 
 type blueprintOutJsonDescribe struct {
 	*blueprintOut
-	Content string `json:"BlueprintTextAsBase64" yaml:"BlueprintTextAsBase64"`
-	Crn     string `json:"Crn" yaml:"Crn"`
+	Content string `json:"blueprintTextAsBase64" yaml:"blueprintTextAsBase64"`
+	Crn     string `json:"crn" yaml:"crn"`
 }
 
 type blueprintOutTableDescribe struct {
 	*blueprintOut
-	Crn string `json:"Crn" yaml:"Crn"`
+	Crn string `json:"crn" yaml:"crn"`
 }
 
 func (b *blueprintOut) DataAsStringArray() []string {

--- a/dataplane/clustertemplate/clustertemplate.go
+++ b/dataplane/clustertemplate/clustertemplate.go
@@ -21,23 +21,23 @@ import (
 var clusterTemplateHeader = []string{"Name", "Description", "StackName", "StackVersion", "Hostgroup Count", "Tags"}
 
 type clusterTemplateOut struct {
-	Name           string `json:"Name" yaml:"Name"`
-	Description    string `json:"Description" yaml:"Description"`
-	StackName      string `json:"StackName" yaml:"StackName"`
-	StackVersion   string `json:"StackVersion" yaml:"StackVersion"`
-	HostgroupCount string `json:"HostgroupCount" yaml:"HostgroupCount"`
-	Tags           string `json:"Tags" yaml:"Tags"`
+	Name           string `json:"name" yaml:"name"`
+	Description    string `json:"description" yaml:"description"`
+	StackName      string `json:"stackName" yaml:"stackName"`
+	StackVersion   string `json:"stackVersion" yaml:"stackVersion"`
+	HostgroupCount string `json:"hostgroupCount" yaml:"hostgroupCount"`
+	Tags           string `json:"tags" yaml:"tags"`
 }
 
 type clusterTemplateOutJsonDescribe struct {
 	*clusterTemplateOut
-	Content string `json:"ClusterTemplateTextAsBase64" yaml:"ClusterTemplateTextAsBase64"`
-	Crn     string `json:"Crn" yaml:"Crn"`
+	Content string `json:"clusterTemplateTextAsBase64" yaml:"clusterTemplateTextAsBase64"`
+	Crn     string `json:"crn" yaml:"crn"`
 }
 
 type clusterTemplateOutTableDescribe struct {
 	*clusterTemplateOut
-	Crn string `json:"Crn" yaml:"Crn"`
+	Crn string `json:"crn" yaml:"crn"`
 }
 
 func (b *clusterTemplateOut) DataAsStringArray() []string {

--- a/dataplane/common/common.go
+++ b/dataplane/common/common.go
@@ -3,9 +3,9 @@ package common
 var CloudResourceHeader = []string{"Name", "Description", "CloudPlatform"}
 
 type CloudResourceOut struct {
-	Name          string `json:"Name" yaml:"Name"`
-	Description   string `json:"Description" yaml:"Description"`
-	CloudPlatform string `json:"CloudPlatform" yaml:"CloudPlatform"`
+	Name          string `json:"name" yaml:"name"`
+	Description   string `json:"description" yaml:"description"`
+	CloudPlatform string `json:"cloudPlatform" yaml:"cloudPlatform"`
 }
 
 func (c *CloudResourceOut) DataAsStringArray() []string {

--- a/dataplane/connectors/connectors.go
+++ b/dataplane/connectors/connectors.go
@@ -20,24 +20,24 @@ var availabilityZonesHeader = []string{"Name"}
 var instanceHeader = []string{"Name", "Cpu", "Memory", "AvailabilityZone"}
 
 type regionsOut struct {
-	Name        string `json:"Name" yaml:"Name"`
-	Description string `json:"Description" yaml:"Description"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
 }
 
 type diskOut struct {
-	Name        string `json:"Name" yaml:"Name"`
-	Description string `json:"Description" yaml:"Description"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
 }
 
 type availabilityZonesOut struct {
-	Name string `json:"Name" yaml:"Name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 type instanceOut struct {
-	Name             string `json:"Name" yaml:"Name"`
-	Cpu              string `json:"Cpu" yaml:"Cpu"`
-	Memory           string `json:"Memory" yaml:"Memory"`
-	AvailabilityZone string `json:"AvailabilityZone" yaml:"AvailabilityZone"`
+	Name             string `json:"name" yaml:"name"`
+	Cpu              string `json:"cpu" yaml:"cpu"`
+	Memory           string `json:"memory" yaml:"memory"`
+	AvailabilityZone string `json:"availabilityZone" yaml:"availabilityZone"`
 }
 
 type hasName interface {

--- a/dataplane/credential/credential.go
+++ b/dataplane/credential/credential.go
@@ -26,10 +26,10 @@ import (
 var AwsPrerequisiteOutputHeader = []string{"Account Id", "CloudPlatform", "External Id", "Policy JSON"}
 
 type awsPrerequisiteOutput struct {
-	AccountId     string `json:"AccountId" yaml:"AccountId"`
-	CloudPlatform string `json:"CloudPlatform" yaml:"CloudPlatform"`
-	ExternalId    string `json:"ExternalId" yaml:"ExternalId"`
-	PolicyJSON    string `json:"PolicyJSON" yaml:"PolicyJSON"`
+	AccountId     string `json:"accountId" yaml:"accountId"`
+	CloudPlatform string `json:"cloudPlatform" yaml:"cloudPlatform"`
+	ExternalId    string `json:"externalId" yaml:"externalId"`
+	PolicyJSON    string `json:"policyJSON" yaml:"policyJSON"`
 }
 
 func (p *awsPrerequisiteOutput) DataAsStringArray() []string {
@@ -243,7 +243,7 @@ func postCredential(client createCredentialClient, credReq *model.CredentialV1Re
 
 type credentialOutDescribe struct {
 	*common.CloudResourceOut
-	CRN string `json:"CRN" yaml:"CRN"`
+	CRN string `json:"crn" yaml:"crn"`
 }
 
 func (c *credentialOutDescribe) DataAsStringArray() []string {

--- a/dataplane/distrox/distrox.go
+++ b/dataplane/distrox/distrox.go
@@ -27,10 +27,10 @@ var stackHeader = []string{"Name", "Crn", "CloudPlatform", "Environment", "Distr
 
 type dxOut struct {
 	common.CloudResourceOut
-	Crn           string `json:"Crn" yaml:"Crn"`
-	Environment   string `json:"Environment" yaml:"Environment"`
-	DistroXStatus string `json:"DistroXStatus" yaml:"DistroXStatus"`
-	ClusterStatus string `json:"ClusterStatus" yaml:"ClusterStatus"`
+	Crn           string `json:"crn" yaml:"crn"`
+	Environment   string `json:"environment" yaml:"environment"`
+	DistroXStatus string `json:"distroXStatus" yaml:"distroXStatus"`
+	ClusterStatus string `json:"clusterStatus" yaml:"clusterStatus"`
 }
 
 type stackOutDescribe struct {

--- a/dataplane/env/environment.go
+++ b/dataplane/env/environment.go
@@ -21,16 +21,16 @@ import (
 var EnvironmentHeader = []string{"Name", "Description", "CloudPlatform", "Status", "Credential", "Regions", "LocationName", "Longitude", "Latitude", "Crn"}
 
 type environment struct {
-	Name          string   `json:"Name" yaml:"Name"`
-	Description   string   `json:"Description" yaml:"Description"`
-	CloudPlatform string   `json:"CloudPlatform" yaml:"CloudPlatform"`
-	Status        string   `json:"Status" yaml:"Status"`
-	Credential    string   `json:"Credential" yaml:"Credential"`
-	Regions       []string `json:"Regions" yaml:"Regions"`
-	LocationName  string   `json:"LocationName" yaml:"LocationName"`
-	Longitude     float64  `json:"Longitude" yaml:"Longitude"`
-	Latitude      float64  `json:"Latitude" yaml:"Latitude"`
-	Crn           string   `json:"Crn" yaml:"Crn"`
+	Name          string   `json:"name" yaml:"name"`
+	Description   string   `json:"description" yaml:"description"`
+	CloudPlatform string   `json:"cloudPlatform" yaml:"cloudPlatform"`
+	Status        string   `json:"status" yaml:"status"`
+	Credential    string   `json:"credential" yaml:"credential"`
+	Regions       []string `json:"regions" yaml:"regions"`
+	LocationName  string   `json:"locationName" yaml:"locationName"`
+	Longitude     float64  `json:"longitude" yaml:"longitude"`
+	Latitude      float64  `json:"latitude" yaml:"latitude"`
+	Crn           string   `json:"crn" yaml:"crn"`
 }
 
 type environmentOutTableDescribe struct {
@@ -39,16 +39,16 @@ type environmentOutTableDescribe struct {
 
 type environmentOutJsonDescribe struct {
 	*environment
-	ProxyConfigs   []string                                  `json:"ProxyConfigs" yaml:"ProxyConfigs"`
-	Network        model.EnvironmentNetworkV1Response        `json:"Network" yaml:"Network"`
-	Telemetry      model.TelemetryResponse                   `json:"Telemetry" yaml:"Telemetry"`
-	Authentication model.EnvironmentAuthenticationV1Response `json:"Authentication" yaml:"Authentication"`
+	ProxyConfigs   []string                                  `json:"proxyConfigs" yaml:"proxyConfigs"`
+	Network        model.EnvironmentNetworkV1Response        `json:"network" yaml:"network"`
+	Telemetry      model.TelemetryResponse                   `json:"telemetry" yaml:"telemetry"`
+	Authentication model.EnvironmentAuthenticationV1Response `json:"authentication" yaml:"authentication"`
 }
 
 type environmentListJsonDescribe struct {
 	*environment
-	Network   model.EnvironmentNetworkV1Response `json:"Network" yaml:"Network"`
-	Telemetry model.TelemetryResponse            `json:"Telemetry" yaml:"Telemetry"`
+	Network   model.EnvironmentNetworkV1Response `json:"network" yaml:"network"`
+	Telemetry model.TelemetryResponse            `json:"telemetry" yaml:"telemetry"`
 }
 
 type environmentClient interface {

--- a/dataplane/freeipa/freeipaoutlist.go
+++ b/dataplane/freeipa/freeipaoutlist.go
@@ -3,10 +3,10 @@ package freeipa
 var listHeader = []string{"Name", "Crn", "EnvironmentCrn", "Status"}
 
 type freeIpaDetails struct {
-	Name           string `json:"Name" yaml:"Name"`
-	CRN            string `json:"CRN" yaml:"CRN"`
-	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
-	Status         string `json:"Status" yaml:"Status"`
+	Name           string `json:"name" yaml:"name"`
+	CRN            string `json:"crn" yaml:"crn"`
+	EnvironmentCrn string `json:"environmentCrn" yaml:"environmentCrn"`
+	Status         string `json:"status" yaml:"status"`
 }
 
 func (ipa *freeIpaDetails) DataAsStringArray() []string {

--- a/dataplane/freeipa/freeipaoutsyncoperation.go
+++ b/dataplane/freeipa/freeipaoutsyncoperation.go
@@ -7,23 +7,23 @@ import (
 var syncStatusHeader = []string{"ID", "Status", "SyncType", "Success", "Failure", "Error", "StartTime", "EndTime"}
 
 type freeIpaOutSyncOperation struct {
-	ID        string          `json:"ID" yaml:"ID"`
-	Status    string          `json:"Status" yaml:"Status"`
-	SyncType  string          `json:"SyncType" yaml:"SyncType"`
-	Success   []successDetail `json:"Success" yaml:"Success"`
-	Failure   []failureDetail `json:"Failure" yaml:"Failure"`
-	Error     string          `json:"Error,omitempty" yaml:"Error,omitempty"`
-	StartTime string          `json:"StartTime" yaml:"StartTime"`
-	EndTime   string          `json:"EndTime,omitempty" yaml:"EndTime,omitempty"`
+	ID        string          `json:"id" yaml:"id"`
+	Status    string          `json:"status" yaml:"status"`
+	SyncType  string          `json:"syncType" yaml:"syncType"`
+	Success   []successDetail `json:"success" yaml:"success"`
+	Failure   []failureDetail `json:"failure" yaml:"failure"`
+	Error     string          `json:"error,omitempty" yaml:"error,omitempty"`
+	StartTime string          `json:"startTime" yaml:"startTime"`
+	EndTime   string          `json:"endTime,omitempty" yaml:"endTime,omitempty"`
 }
 
 type successDetail struct {
-	Environment string `json:"Environment" yaml:"Environment"`
+	Environment string `json:"environment" yaml:"environment"`
 }
 
 type failureDetail struct {
-	Environment string `json:"Environment" yaml:"Environment"`
-	Details     string `json:"Details" yaml:"Details"`
+	Environment string `json:"environment" yaml:"environment"`
+	Details     string `json:"details" yaml:"details"`
 }
 
 func (f *freeIpaOutSyncOperation) DataAsStringArray() []string {

--- a/dataplane/imagecatalog/imagecatalogs.go
+++ b/dataplane/imagecatalog/imagecatalogs.go
@@ -19,15 +19,15 @@ import (
 var imagecatalogHeader = []string{"Name", "Description", "Default", "URL"}
 
 type imagecatalogOut struct {
-	Name        string `json:"Name" yaml:"Name"`
-	Description string `json:"Description" yaml:"Description"`
-	Default     bool   `json:"Default" yaml:"Default"`
-	URL         string `json:"URL" yaml:"URL"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
+	Default     bool   `json:"default" yaml:"default"`
+	URL         string `json:"url" yaml:"url"`
 }
 
 type imagecatalogOutDescribe struct {
 	*imagecatalogOut
-	CRN string `json:"CRN" yaml:"CRN"`
+	CRN string `json:"crn" yaml:"crn"`
 }
 
 func (r *imagecatalogOut) DataAsStringArray() []string {
@@ -41,10 +41,10 @@ func (b *imagecatalogOutDescribe) DataAsStringArray() []string {
 var imageHeader = []string{"Date", "Description", "Version", "ImageID"}
 
 type imageOut struct {
-	Date        string `json:"Date" yaml:"Date"`
-	Description string `json:"Description" yaml:"Description"`
-	Version     string `json:"Version" yaml:"Version"`
-	ImageID     string `json:"ImageID" yaml:"ImageID"`
+	Date        string `json:"date" yaml:"date"`
+	Description string `json:"description" yaml:"description"`
+	Version     string `json:"version" yaml:"version"`
+	ImageID     string `json:"imageID" yaml:"imageID"`
 }
 
 func (r *imageOut) DataAsStringArray() []string {
@@ -54,14 +54,14 @@ func (r *imageOut) DataAsStringArray() []string {
 var imageDetailsHeader = []string{"Date", "Description", "Ambari Version", "ImageID", "OS", "OS Type", "Images", "Package Versions"}
 
 type imageDetailsOut struct {
-	Date            string                       `json:"Date" yaml:"Date"`
-	Description     string                       `json:"Description" yaml:"Description"`
-	Version         string                       `json:"Version" yaml:"Version"`
-	ImageID         string                       `json:"ImageID" yaml:"ImageID"`
-	Os              string                       `json:"OS" yaml:"OS"`
-	OsType          string                       `json:"OSType" yaml:"OSType"`
-	Images          map[string]map[string]string `json:"Images" yaml:"Images"`
-	PackageVersions map[string]string            `json:"PackageVersions" yaml:"PackageVersions"`
+	Date            string                       `json:"date" yaml:"date"`
+	Description     string                       `json:"description" yaml:"description"`
+	Version         string                       `json:"version" yaml:"version"`
+	ImageID         string                       `json:"imageID" yaml:"imageID"`
+	Os              string                       `json:"os" yaml:"os"`
+	OsType          string                       `json:"osType" yaml:"osType"`
+	Images          map[string]map[string]string `json:"images" yaml:"images"`
+	PackageVersions map[string]string            `json:"packageVersions" yaml:"packageVersions"`
 }
 
 func (r *imageDetailsOut) DataAsStringArray() []string {

--- a/dataplane/kerberos/kerberos.go
+++ b/dataplane/kerberos/kerberos.go
@@ -16,15 +16,15 @@ import (
 var Header = []string{"Name", "Description", "Type", "Environments", "Crn"}
 
 type kerberos struct {
-	Name           string `json:"Name" yaml:"Name"`
-	Description    string `json:"Description" yaml:"Description"`
-	Type           string `json:"Type" yaml:"Type"`
+	Name           string `json:"name" yaml:"name"`
+	Description    string `json:"description" yaml:"description"`
+	Type           string `json:"type" yaml:"type"`
 	EnvironmentCrn string
 }
 
 type kerberosOutDescribe struct {
 	*kerberos
-	Crn string `json:"Crn" yaml:"Crn"`
+	Crn string `json:"crn" yaml:"crn"`
 }
 
 type freeIpaKerberosClient interface {

--- a/dataplane/kubernetes/kubernetes.go
+++ b/dataplane/kubernetes/kubernetes.go
@@ -19,13 +19,13 @@ import (
 var kubernetesHeader = []string{"Name", "Description", "Environments"}
 
 type kubernetes struct {
-	Name        string `json:"Name" yaml:"Name"`
-	Description string `json:"Description" yaml:"Description"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
 }
 
 type kubernetesOutDescribe struct {
 	*kubernetes
-	ID string `json:"ID" yaml:"ID"`
+	ID string `json:"id" yaml:"id"`
 }
 
 func (k *kubernetes) DataAsStringArray() []string {

--- a/dataplane/ldap/ldap.go
+++ b/dataplane/ldap/ldap.go
@@ -29,27 +29,27 @@ var Header = []string{"Name", "Description", "Server", "Domain", "DirectoryType"
 	"GroupMemberAttribute", "GroupNameAttribute", "GroupObjectClass", "GroupSearchBase", "Certificate", "Environments"}
 
 type ldap struct {
-	Name                 string `json:"Name" yaml:"Name"`
-	Description          string `json:"Description" yaml:"Description"`
-	Server               string `json:"Server" yaml:"Server"`
-	Domain               string `json:"Domain,omitempty" yaml:"Domain,omitempty"`
-	DirectoryType        string `json:"DirectoryType" yaml:"DirectoryType"`
-	UserSearchBase       string `json:"UserSearchBase" yaml:"UserSearchBase"`
-	UserDnPattern        string `json:"UserDnPattern" yaml:"UserDnPattern"`
-	UserNameAttribute    string `json:"UserNameAttribute,omitempty" yaml:"UserNameAttribute,omitempty"`
-	UserObjectClass      string `json:"UserObjectClass,omitempty" yaml:"UserObjectClass,omitempty"`
-	GroupMemberAttribute string `json:"GroupMemberAttribute,omitempty" yaml:"GroupMemberAttribute,omitempty"`
-	GroupNameAttribute   string `json:"GroupNameAttribute,omitempty" yaml:"GroupNameAttribute,omitempty"`
-	GroupObjectClass     string `json:"GroupObjectClass,omitempty" yaml:"GroupObjectClass,omitempty"`
-	GroupSearchBase      string `json:"GroupSearchBase,omitempty" yaml:"GroupSearchBase,omitempty"`
-	AdminGroup           string `json:"AdminGroup,omitempty" yaml:"AdminGroup,omitempty"`
-	Certificate          string `json:"Certificate,omitempty" yaml:"Certificate,omitempty"`
+	Name                 string `json:"name" yaml:"name"`
+	Description          string `json:"description" yaml:"description"`
+	Server               string `json:"server" yaml:"server"`
+	Domain               string `json:"domain,omitempty" yaml:"domain,omitempty"`
+	DirectoryType        string `json:"directoryType" yaml:"directoryType"`
+	UserSearchBase       string `json:"userSearchBase" yaml:"userSearchBase"`
+	UserDnPattern        string `json:"userDnPattern" yaml:"userDnPattern"`
+	UserNameAttribute    string `json:"userNameAttribute,omitempty" yaml:"userNameAttribute,omitempty"`
+	UserObjectClass      string `json:"userObjectClass,omitempty" yaml:"userObjectClass,omitempty"`
+	GroupMemberAttribute string `json:"groupMemberAttribute,omitempty" yaml:"groupMemberAttribute,omitempty"`
+	GroupNameAttribute   string `json:"groupNameAttribute,omitempty" yaml:"groupNameAttribute,omitempty"`
+	GroupObjectClass     string `json:"groupObjectClass,omitempty" yaml:"groupObjectClass,omitempty"`
+	GroupSearchBase      string `json:"groupSearchBase,omitempty" yaml:"groupSearchBase,omitempty"`
+	AdminGroup           string `json:"adminGroup,omitempty" yaml:"ddminGroup,omitempty"`
+	Certificate          string `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	EnvironmentCrn       string
 }
 
 type ldapOutDescribe struct {
 	*ldap
-	Crn string `json:"Crn" yaml:"Crn"`
+	Crn string `json:"crn" yaml:"crn"`
 }
 
 func (l *ldap) DataAsStringArray() []string {
@@ -64,9 +64,9 @@ func (l *ldapOutDescribe) DataAsStringArray() []string {
 var Users = []string{"Distinguished Names", "Email", "Member of Group"}
 
 type ldapUserSearchResult struct {
-	Name     string `json:"Name" yaml:"Name"`
-	Email    string `json:"Email" yaml:"Email"`
-	MemberOf string `json:"MemberOf" yaml:"MemberOf"`
+	Name     string `json:"name" yaml:"name"`
+	Email    string `json:"email" yaml:"email"`
+	MemberOf string `json:"memberOf" yaml:"memberOf"`
 }
 
 func (l *ldapUserSearchResult) DataAsStringArray() []string {
@@ -76,7 +76,7 @@ func (l *ldapUserSearchResult) DataAsStringArray() []string {
 var Groups = []string{"Distinguished Names"}
 
 type ldapGroupSearchResult struct {
-	Name string `json:"Name" yaml:"Name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 func (l *ldapGroupSearchResult) DataAsStringArray() []string {

--- a/dataplane/mpack/mpack.go
+++ b/dataplane/mpack/mpack.go
@@ -21,12 +21,12 @@ type mpackClient interface {
 var mpackHeader = []string{"Name", "Description", "URL", "Purge", "PurgeList", "Force"}
 
 type mpack struct {
-	Name        string `json:"Name" yaml:"Name"`
-	Description string `json:"Description" yaml:"Description"`
-	URL         string `json:"URL" yaml:"URL"`
-	Purge       string `json:"Purge" yaml:"Purge"`
-	PurgeList   string `json:"PurgeList" yaml:"PurgeList"`
-	Force       string `json:"Force" yaml:"Force"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
+	URL         string `json:"url" yaml:"url"`
+	Purge       string `json:"purge" yaml:"purge"`
+	PurgeList   string `json:"purgeList" yaml:"purgeList"`
+	Force       string `json:"force" yaml:"force"`
 }
 
 func (m *mpack) DataAsStringArray() []string {

--- a/dataplane/proxy/proxy.go
+++ b/dataplane/proxy/proxy.go
@@ -22,11 +22,11 @@ type proxyClient interface {
 var Header = []string{"Name", "Host", "Port", "Protocol", "Crn"}
 
 type proxy struct {
-	Name     string `json:"Name" yaml:"Name"`
-	Host     string `json:"Host" yaml:"Host"`
-	Port     string `json:"Port" yaml:"Port"`
-	Protocol string `json:"Protocol" yaml:"Protocol"`
-	Crn      string `json:"Crn" yaml:"Crn"`
+	Name     string `json:"name" yaml:"name"`
+	Host     string `json:"host" yaml:"host"`
+	Port     string `json:"port" yaml:"port"`
+	Protocol string `json:"protocol" yaml:"protocol"`
+	Crn      string `json:"crn" yaml:"crn"`
 }
 
 func (p *proxy) DataAsStringArray() []string {

--- a/dataplane/rds/rds.go
+++ b/dataplane/rds/rds.go
@@ -19,17 +19,17 @@ import (
 var rdsHeader = []string{"Name", "Description", "ConnectionURL", "DatabaseEngine", "Type", "Driver"}
 
 type rds struct {
-	Name           string `json:"Name" yaml:"Name"`
-	Description    string `json:"Description" yaml:"Description"`
-	URL            string `json:"ConnectionURL" yaml:"ConnectionURL"`
-	DatabaseEngine string `json:"DatabaseEngine" yaml:"DatabaseEngine"`
-	Type           string `json:"Type" yaml:"Type"`
-	Driver         string `json:"Driver" yaml:"Driver"`
+	Name           string `json:"name" yaml:"name"`
+	Description    string `json:"description" yaml:"description"`
+	URL            string `json:"connectionURL" yaml:"connectionURL"`
+	DatabaseEngine string `json:"databaseEngine" yaml:"databaseEngine"`
+	Type           string `json:"type" yaml:"type"`
+	Driver         string `json:"driver" yaml:"driver"`
 }
 
 type rdsOutDescribe struct {
 	*rds
-	ID string `json:"ID" yaml:"ID"`
+	ID string `json:"id" yaml:"id"`
 }
 
 func (r *rds) DataAsStringArray() []string {

--- a/dataplane/recipe/recipe.go
+++ b/dataplane/recipe/recipe.go
@@ -19,20 +19,20 @@ import (
 var recipeHeader = []string{"Name", "Description", "Execution Type"}
 
 type recipeOut struct {
-	Name          string `json:"Name" yaml:"Name"`
-	Description   string `json:"Description" yaml:"Description"`
-	ExecutionType string `json:"ExecutionType" yaml:"ExecutionType"`
+	Name          string `json:"name" yaml:"name"`
+	Description   string `json:"description" yaml:"description"`
+	ExecutionType string `json:"executionType" yaml:"executionType"`
 }
 
 type recipeOutJsonDescribe struct {
 	*recipeOut
-	Content string `json:"RecipeTextAsBase64" yaml:"RecipeTextAsBase64"`
-	Crn     string `json:"CRN" yaml:"CRN"`
+	Content string `json:"recipeTextAsBase64" yaml:"recipeTextAsBase64"`
+	Crn     string `json:"crn" yaml:"crn"`
 }
 
 type recipeOutTableDescribe struct {
 	*recipeOut
-	Crn string `json:"CRN" yaml:"CRN"`
+	Crn string `json:"crn" yaml:"crn"`
 }
 
 func (r *recipeOut) DataAsStringArray() []string {

--- a/dataplane/redbeams/redbeams.go
+++ b/dataplane/redbeams/redbeams.go
@@ -20,17 +20,17 @@ type ClientRedbeams oauth.Redbeams
 var serverListHeader = []string{"Name", "Description", "Crn", "EnvironmentCrn", "Status", "ResourceStatus", "DatabaseVendor", "Host", "Port"}
 
 type serverDetails struct {
-	Name           string `json:"Name" yaml:"Name"`
-	Description    string `json:"Description" yaml:"Description"`
-	CRN            string `json:"CRN" yaml:"CRN"`
-	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
-	Status         string `json:"Status" yaml:"Status"`
-	StatusReason   string `json:"StatusReason" yaml:"StatusReason"`
-	ResourceStatus string `json:"ResourceStatus" yaml:"ResourceStatus"`
-	DatabaseVendor string `json:"DatabaseVendor" yaml:"DatabaseVendor"`
-	Host           string `json:"Host" yaml:"Host"`
-	Port           int32  `json:"Port" yaml:"Port"`
-	CreationDate   int64  `json:"CreationDate" yaml:"CreationDate"`
+	Name           string `json:"name" yaml:"name"`
+	Description    string `json:"description" yaml:"description"`
+	CRN            string `json:"crn" yaml:"crn"`
+	EnvironmentCrn string `json:"environmentCrn" yaml:"environmentCrn"`
+	Status         string `json:"status" yaml:"status"`
+	StatusReason   string `json:"statusReason" yaml:"statusReason"`
+	ResourceStatus string `json:"resourceStatus" yaml:"resourceStatus"`
+	DatabaseVendor string `json:"databaseVendor" yaml:"databaseVendor"`
+	Host           string `json:"host" yaml:"host"`
+	Port           int32  `json:"port" yaml:"port"`
+	CreationDate   int64  `json:"creationDate" yaml:"creationDate"`
 }
 
 func (server *serverDetails) DataAsStringArray() []string {
@@ -68,10 +68,10 @@ func NewDetailsFromResponse(r *model.DatabaseServerV4Response) *serverDetails {
 var statusListHeader = []string{"Name", "Crn", "EnvironmentCrn", "Status"}
 
 type serverStatusDetails struct {
-	Name           string `json:"Name" yaml:"Name"`
-	CRN            string `json:"CRN" yaml:"CRN"`
-	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
-	Status         string `json:"Status" yaml:"Status"`
+	Name           string `json:"name" yaml:"name"`
+	CRN            string `json:"crn" yaml:"crn"`
+	EnvironmentCrn string `json:"environmentCrn" yaml:"environmentCrn"`
+	Status         string `json:"status" yaml:"status"`
 }
 
 func (status *serverStatusDetails) DataAsStringArray() []string {
@@ -229,13 +229,13 @@ func DeleteDatabaseServer(c *cli.Context) {
 var dbListHeader = []string{"Name", "Description", "Crn", "EnvironmentCrn", "DatabaseVendor", "ConnectionURL"}
 
 type dbDetails struct {
-	Name           string `json:"Name" yaml:"Name"`
-	Description    string `json:"Description" yaml:"Description"`
-	CRN            string `json:"CRN" yaml:"CRN"`
-	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
-	DatabaseEngine string `json:"DatabaseEngine" yaml:"DatabaseEngine"`
-	ConnectionURL  string `json:"ConnectionURL" yaml:"ConnectionURL"`
-	CreationDate   int64  `json:"CreationDate" yaml:"CreationDate"`
+	Name           string `json:"name" yaml:"name"`
+	Description    string `json:"description" yaml:"description"`
+	CRN            string `json:"crn" yaml:"crn"`
+	EnvironmentCrn string `json:"environmentCrn" yaml:"environmentCrn"`
+	DatabaseEngine string `json:"databaseEngine" yaml:"databaseEngine"`
+	ConnectionURL  string `json:"connectionURL" yaml:"connectionURL"`
+	CreationDate   int64  `json:"creationDate" yaml:"creationDate"`
 }
 
 func (db *dbDetails) DataAsStringArray() []string {

--- a/dataplane/sdx/sdx.go
+++ b/dataplane/sdx/sdx.go
@@ -24,16 +24,16 @@ import (
 var sdxClusterHeader = []string{"Crn", "Name", "EnvironmentName", "EnvironmentCrn", "StackCrn", "DatabaseServerCrn", "Status", "StatusReason"}
 
 type sdxClusterOutput struct {
-	Crn                        string `json:"Crn" yaml:"Crn"`
-	Name                       string `json:"Name" yaml:"Name"`
-	Environment                string `json:"EnvironmentName" yaml:"EnvironmentName"`
-	EnvironmentCrn             string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
-	StackCrn                   string `json:"StackCrn" yaml:"StackCrn"`
-	DatabaseServerCrn          string `json:"DatabaseServerCrn" yaml:"DatabaseServerCrn"`
-	CloudStorageBaseLocation   string `json:"CloudStorageBaseLocation" yaml:"CloudStorageBaseLocation"`
-	CloudStorageFileSystemType string `json:"CloudStorageFileSystemType" yaml:"CloudStorageFileSystemType"`
-	Status                     string `json:"Status" yaml:"Status"`
-	StatusReason               string `json:"StatusReason" yaml:"StatusReason"`
+	Crn                        string `json:"crn" yaml:"crn"`
+	Name                       string `json:"name" yaml:"Name"`
+	Environment                string `json:"environmentName" yaml:"environmentName"`
+	EnvironmentCrn             string `json:"environmentCrn" yaml:"environmentCrn"`
+	StackCrn                   string `json:"stackCrn" yaml:"stackCrn"`
+	DatabaseServerCrn          string `json:"databaseServerCrn" yaml:"databaseServerCrn"`
+	CloudStorageBaseLocation   string `json:"cloudStorageBaseLocation" yaml:"cloudStorageBaseLocation"`
+	CloudStorageFileSystemType string `json:"cloudStorageFileSystemType" yaml:"cloudStorageFileSystemType"`
+	Status                     string `json:"status" yaml:"status"`
+	StatusReason               string `json:"statusReason" yaml:"statusReason"`
 }
 
 func (r *sdxClusterOutput) DataAsStringArray() []string {

--- a/dataplane/stack/stack.go
+++ b/dataplane/stack/stack.go
@@ -28,9 +28,9 @@ var stackHeader = []string{"Name", "CloudPlatform", "EnvironmentCrn", "StackStat
 
 type stackOut struct {
 	common.CloudResourceOut
-	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
-	StackStatus    string `json:"StackStatus" yaml:"StackStatus"`
-	ClusterStatus  string `json:"ClusterStatus" yaml:"ClusterStatus"`
+	EnvironmentCrn string `json:"environmentCrn" yaml:"environmentCrn"`
+	StackStatus    string `json:"stackStatus" yaml:"stackStatus"`
+	ClusterStatus  string `json:"clusterStatus" yaml:"clusterStatus"`
 }
 
 type stackOutDescribe struct {

--- a/dataplane/userprofile/userprofile.go
+++ b/dataplane/userprofile/userprofile.go
@@ -16,11 +16,11 @@ import (
 var showClustersPreferencesHeader = []string{"Show terminated clusters", "Source of config", "Timeout (days)", "Timeout (hours)", "Timeout (minutes)"}
 
 type showClustersPreferencesOut struct {
-	ShowTerminatedClustersActive bool   `json:"Show terminated clusters" yaml:"Show terminated clusters"`
-	Source                       string `json:"Source of config" yaml:"Source of config"`
-	TimeoutDays                  int32  `json:"Show terminated clusters timeout (days)" yaml:"Show terminated clusters timeout (days)"`
-	TimeoutHours                 int32  `json:"Show terminated clusters timeout (hours)" yaml:"Show terminated clusters timeout (hours)"`
-	TimeoutMinutes               int32  `json:"Show terminated clusters timeout (minutes)" yaml:"Show terminated clusters timeout (minutes)"`
+	ShowTerminatedClustersActive bool   `json:"show terminated clusters" yaml:"show terminated clusters"`
+	Source                       string `json:"source of config" yaml:"source of config"`
+	TimeoutDays                  int32  `json:"show terminated clusters timeout (days)" yaml:"show terminated clusters timeout (days)"`
+	TimeoutHours                 int32  `json:"show terminated clusters timeout (hours)" yaml:"show terminated clusters timeout (hours)"`
+	TimeoutMinutes               int32  `json:"show terminated clusters timeout (minutes)" yaml:"show terminated clusters timeout (minutes)"`
 }
 
 func (r *showClustersPreferencesOut) DataAsStringArray() []string {

--- a/dataplane/workspace/workspace.go
+++ b/dataplane/workspace/workspace.go
@@ -17,12 +17,12 @@ import (
 var workspaceListHeader = []string{"Name", "Description", "Permissions"}
 
 type workspaceListOut struct {
-	Workspace *model.WorkspaceV4Response `json:"Workspace" yaml:"Workspace"`
+	Workspace *model.WorkspaceV4Response `json:"workspace" yaml:"workspace"`
 }
 
 type workspaceListOutDescribe struct {
 	*workspaceListOut
-	ID string `json:"ID" yaml:"ID"`
+	ID string `json:"id" yaml:"id"`
 }
 
 func (o *workspaceListOut) DataAsStringArray() []string {

--- a/tests/spec/integration/credential.rb
+++ b/tests/spec/integration/credential.rb
@@ -42,10 +42,10 @@ RSpec.describe 'Credential test cases', :type => :aruba, :feature => "Credential
       expect(result.stdout.empty?).to be_falsy
       [JSON.parse(result.stdout)].flatten.each do |s|
             expect(s).to include_json(
-              AccountId: /.*/,
-              CloudPlatform: /.*/,
-              ExternalId: /.*/,
-              PolicyJSON: /.*/
+              accountId: /.*/,
+              cloudPlatform: /.*/,
+              externalId: /.*/,
+              policyJSON: /.*/
           )
       end
     end


### PR DESCRIPTION
 - all responses now start with lowercase so it's more similar to the API responses leading to less confusion better jq magic

- need to validate with QAAS if that's what they desire

```
API response:
{"crn":"crn:altus:sdx:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:sdxcluster:975efde2-7d0e-4606-b327-b847381f551f","name":"zol-dl-z","clusterShape":"LIGHT_DUTY","status":"RUNNING","statusReason":null,"environmentName":"zol-sdx-z","environmentCrn":"crn:altus:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:4d6402b5-5e07-407c-af8e-957978b26456","databaseServerCrn":null,"stackCrn":null,"created":null,"cloudStorageBaseLocation":null,"cloudStorageFileSystemType":null}

new CLI output:
{
  "crn": "crn:altus:sdx:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:sdxcluster:975efde2-7d0e-4606-b327-b847381f551f",
  "name": "zol-dl-z",
  "environmentName": "zol-sdx-z",
  "environmentCrn": "crn:altus:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:4d6402b5-5e07-407c-af8e-957978b26456",
  "stackCrn": "",
  "databaseServerCrn": "",
  "cloudStorageBaseLocation": "",
  "cloudStorageFileSystemType": "",
  "status": "RUNNING",
  "statusReason": ""
}
```