### PR TITLE
CB-3638 Add type and resource status to db output, fix int conversions

### DIFF
--- a/dataplane/api-redbeams/model/database_v4_response.go
+++ b/dataplane/api-redbeams/model/database_v4_response.go
@@ -6,6 +6,8 @@ package model
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
+
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -61,6 +63,10 @@ type DatabaseV4Response struct {
 	// Pattern: (^[a-z][-a-z0-9]*[a-z0-9]$)
 	Name *string `json:"name"`
 
+	// Ownership status of the database server
+	// Enum: [UNKNOWN SERVICE_MANAGED USER_MANAGED]
+	ResourceStatus string `json:"resourceStatus,omitempty"`
+
 	// Type of database, i.e., the service name that will use the database (HIVE, DRUID, SUPERSET, RANGER, ...)
 	// Required: true
 	// Max Length: 56
@@ -106,6 +112,10 @@ func (m *DatabaseV4Response) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateResourceStatus(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -232,6 +242,52 @@ func (m *DatabaseV4Response) validateName(formats strfmt.Registry) error {
 	}
 
 	if err := validate.Pattern("name", "body", string(*m.Name), `(^[a-z][-a-z0-9]*[a-z0-9]$)`); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var databaseV4ResponseTypeResourceStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["UNKNOWN","SERVICE_MANAGED","USER_MANAGED"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		databaseV4ResponseTypeResourceStatusPropEnum = append(databaseV4ResponseTypeResourceStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// DatabaseV4ResponseResourceStatusUNKNOWN captures enum value "UNKNOWN"
+	DatabaseV4ResponseResourceStatusUNKNOWN string = "UNKNOWN"
+
+	// DatabaseV4ResponseResourceStatusSERVICEMANAGED captures enum value "SERVICE_MANAGED"
+	DatabaseV4ResponseResourceStatusSERVICEMANAGED string = "SERVICE_MANAGED"
+
+	// DatabaseV4ResponseResourceStatusUSERMANAGED captures enum value "USER_MANAGED"
+	DatabaseV4ResponseResourceStatusUSERMANAGED string = "USER_MANAGED"
+)
+
+// prop value enum
+func (m *DatabaseV4Response) validateResourceStatusEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, databaseV4ResponseTypeResourceStatusPropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *DatabaseV4Response) validateResourceStatus(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ResourceStatus) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateResourceStatusEnum("resourceStatus", "body", m.ResourceStatus); err != nil {
 		return err
 	}
 

--- a/dataplane/redbeams/redbeams.go
+++ b/dataplane/redbeams/redbeams.go
@@ -3,6 +3,7 @@ package redbeams
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/hortonworks/cb-cli/dataplane/api-redbeams/client/database_servers"
@@ -17,7 +18,7 @@ import (
 
 type ClientRedbeams oauth.Redbeams
 
-var serverListHeader = []string{"Name", "Description", "Crn", "EnvironmentCrn", "Status", "ResourceStatus", "DatabaseVendor", "Host", "Port"}
+var serverListHeader = []string{"Name", "Description", "Crn", "EnvironmentCrn", "Status", "ResourceStatus", "DatabaseVendor", "Host", "Port", "CreationDate"}
 
 type serverDetails struct {
 	Name           string `json:"Name" yaml:"Name"`
@@ -34,7 +35,7 @@ type serverDetails struct {
 }
 
 func (server *serverDetails) DataAsStringArray() []string {
-	return []string{server.Name, server.Description, server.CRN, server.EnvironmentCrn, server.Status, server.DatabaseVendor, server.Host, string(server.Port)}
+	return []string{server.Name, server.Description, server.CRN, server.EnvironmentCrn, server.Status, server.ResourceStatus, server.DatabaseVendor, server.Host, strconv.FormatInt(int64(server.Port), 10), strconv.FormatInt(server.CreationDate, 10)}
 }
 
 func NewDetailsFromResponse(r *model.DatabaseServerV4Response) *serverDetails {
@@ -227,28 +228,32 @@ func DeleteDatabaseServer(c *cli.Context) {
 	output.Write(serverListHeader, row)
 }
 
-var dbListHeader = []string{"Name", "Description", "Crn", "EnvironmentCrn", "DatabaseVendor", "ConnectionURL"}
+var dbListHeader = []string{"Name", "Type", "Description", "Crn", "EnvironmentCrn", "DatabaseVendor", "ConnectionURL", "ResourceStatus", "CreationDate"}
 
 type dbDetails struct {
 	Name           string `json:"Name" yaml:"Name"`
+	Type           string `json:"Type" yaml:"Type"`
 	Description    string `json:"Description" yaml:"Description"`
 	CRN            string `json:"CRN" yaml:"CRN"`
 	EnvironmentCrn string `json:"EnvironmentCrn" yaml:"EnvironmentCrn"`
 	DatabaseEngine string `json:"DatabaseEngine" yaml:"DatabaseEngine"`
 	ConnectionURL  string `json:"ConnectionURL" yaml:"ConnectionURL"`
+	ResourceStatus string `json:"ResourceStatus" yaml:"ResourceStatus"`
 	CreationDate   int64  `json:"CreationDate" yaml:"CreationDate"`
 }
 
 func (db *dbDetails) DataAsStringArray() []string {
-	return []string{db.Name, db.Description, db.CRN, db.EnvironmentCrn, db.DatabaseEngine, db.ConnectionURL, string(db.CreationDate)}
+	return []string{db.Name, db.Type, db.Description, db.CRN, db.EnvironmentCrn, db.DatabaseEngine, db.ConnectionURL, db.ResourceStatus, strconv.FormatInt(db.CreationDate, 10)}
 }
 
 func NewDetailsFromDbResponse(r *model.DatabaseV4Response) *dbDetails {
 	details := &dbDetails{
 		Name:           *r.Name,
+		Type:           *r.Type,
 		CRN:            r.Crn,
 		EnvironmentCrn: *r.EnvironmentCrn,
 		ConnectionURL:  *r.ConnectionURL,
+		ResourceStatus: r.ResourceStatus,
 		CreationDate:   r.CreationDate,
 	}
 


### PR DESCRIPTION
The following changes are made to the redbeams commands:

* The database response object includes the new resource status field.
* The existing type field in the database response object is now
  included in output.
* String conversions of ports and creation dates for table output are
  fixed, and tabular output is generally fixed.