### PR TITLE
CB-3087 Introduce new REDBEAMS integration test cases (part 2)

### DIFF
--- a/tests/requests/redbeams/create-redbeams-request.json
+++ b/tests/requests/redbeams/create-redbeams-request.json
@@ -1,0 +1,15 @@
+{
+  "databaseServer": {
+    "aws": {
+      "backupRetentionPeriod": 1,
+      "engineVersion": "10.6"
+    },
+    "databaseVendor": "postgres",
+    "instanceType": "db.m3.medium",
+    "port": 6789,
+    "rootUserName": "dbroot",
+    "rootUserPassword": "cloudera1",
+    "storageSize": 40
+  },
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs"
+}

--- a/tests/requests/redbeams/register-redbeams-request.json
+++ b/tests/requests/redbeams/register-redbeams-request.json
@@ -1,0 +1,10 @@
+{
+  "connectionPassword": "dbroot",
+  "connectionUserName": "cloudera1",
+  "databaseVendor": "postgres",
+  "description": "auto testing",
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "host": "dbsvr-a12b3c4e-f5g6-78h9-iijk-lm0n1op23qr4.s5uvwxyzabcd.eu-west-1.rds.amazonaws.com",
+  "name": "dbstck-mock-amazon-12345a6b7cd8e9012",
+  "port": 5432
+}

--- a/tests/responses/redbeams/create-redbeams-response.json
+++ b/tests/responses/redbeams/create-redbeams-response.json
@@ -1,0 +1,7 @@
+{
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "name": "dbstck-aszegedi-amazon-090b2a5b65202e0ce",
+  "resourceCrn": "crn:cdp:redbeams:us-west-1:hortonworks:databaseServer:740ef9d3-3869-41c1-95db-b27cbced0801",
+  "status": "REQUESTED",
+  "statusReason": ""
+}

--- a/tests/responses/redbeams/dbs.json
+++ b/tests/responses/redbeams/dbs.json
@@ -1,5 +1,3 @@
 {
-  "responses":[
-
-  ]
+  "responses": []
 }

--- a/tests/responses/redbeams/dbserver.json
+++ b/tests/responses/redbeams/dbserver.json
@@ -1,0 +1,23 @@
+{
+  "name": "dbstck-mock-amazon-12345a6b7cd8e9012",
+  "host": "dbsvr-a12b3c4e-f5g6-78h9-iijk-lm0n1op23qr4.s5uvwxyzabcd.eu-west-1.rds.amazonaws.com",
+  "port": 5432,
+  "databaseVendor": "postgres",
+  "connectionDriver": "org.postgresql.Driver",
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "id": 1,
+  "crn": "crn:cdp:redbeams:us-west-1:hortonworks:databaseServer:1abc234d-ee55-6f78-gh9i-01234jklm56n",
+  "databaseVendorDisplayName": "PostgreSQL",
+  "connectionUserName": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionusername/7903e0aa-2ca9-4ed0-a9ef-26012518467c-16d727a65ff"
+  },
+  "connectionPassword": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionpassword/8a7ca233-581f-4ed3-8723-481d9f7b9470-16d726d8bfa"
+  },
+  "creationDate": 1569582844884,
+  "resourceStatus": "SERVICE_MANAGED",
+  "status": "AVAILABLE",
+  "statusReason": ""
+}

--- a/tests/responses/redbeams/delete-redbeams-response.json
+++ b/tests/responses/redbeams/delete-redbeams-response.json
@@ -1,0 +1,23 @@
+{
+  "name": "dbstck-mock-amazon-12345a6b7cd8e9012",
+  "host": "dbsvr-a12b3c4e-f5g6-78h9-iijk-lm0n1op23qr4.s5uvwxyzabcd.eu-west-1.rds.amazonaws.com",
+  "port": 5432,
+  "databaseVendor": "postgres",
+  "connectionDriver": "org.postgresql.Driver",
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "id": 1,
+  "crn": "crn:cdp:redbeams:us-west-1:hortonworks:databaseServer:1abc234d-ee55-6f78-gh9i-01234jklm56n",
+  "databaseVendorDisplayName": "PostgreSQL",
+  "connectionUserName": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionusername/a65395a0-3df4-4a0d-8ca1-82ab2f904c7c-16d8198841c"
+  },
+  "connectionPassword": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionpassword/8ef94d3f-0cd3-40f3-99c4-d3fc28178a39-16d8188f2ec"
+  },
+  "creationDate": 1569836298944,
+  "resourceStatus": "SERVICE_MANAGED",
+  "status": "DELETE_REQUESTED",
+  "statusReason": ""
+}

--- a/tests/responses/redbeams/register-redbeams-response.json
+++ b/tests/responses/redbeams/register-redbeams-response.json
@@ -1,0 +1,23 @@
+{
+  "name": "dbstck-mock-amazon-12345a6b7cd8e9012",
+  "description": "auto testing",
+  "host": "dbsvr-a12b3c4e-f5g6-78h9-iijk-lm0n1op23qr4.s5uvwxyzabcd.eu-west-1.rds.amazonaws.com",
+  "port": 5432,
+  "databaseVendor": "postgres",
+  "connectionDriver": "org.postgresql.Driver",
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "id": 1,
+  "crn": "crn:cdp:redbeams:us-west-1:hortonworks:databaseServer:1abc234d-ee55-6f78-gh9i-01234jklm56n",
+  "databaseVendorDisplayName": "PostgreSQL",
+  "connectionUserName": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionusername/7903e0aa-2ca9-4ed0-a9ef-26012518467c-16d727a65ff"
+  },
+  "connectionPassword": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionpassword/8a7ca233-581f-4ed3-8723-481d9f7b9470-16d726d8bfa"
+  },
+  "creationDate": 1569582844884,
+  "resourceStatus": "USER_MANAGED",
+  "status": "AVAILABLE"
+}

--- a/tests/responses/redbeams/release-redbeams-response.json
+++ b/tests/responses/redbeams/release-redbeams-response.json
@@ -1,0 +1,20 @@
+{
+  "name": "dbstck-mock-amazon-12345a6b7cd8e9012",
+  "databaseVendor": "postgres",
+  "connectionDriver": "org.postgresql.Driver",
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "id": 1,
+  "crn": "crn:cdp:redbeams:us-west-1:hortonworks:databaseServer:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "databaseVendorDisplayName": "PostgreSQL",
+  "connectionUserName": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionusername/e99da81b-8a3d-4655-a7ee-611f42ebf996-16d82b1f18d"
+  },
+  "connectionPassword": {
+    "enginePath": "secret",
+    "secretPath": "redbeams/shared/databaseserverconfig/connectionpassword/9459769b-04d2-4b64-a032-35b6249fda30-16d82b1f197"
+  },
+  "creationDate": 1569855762828,
+  "resourceStatus": "USER_MANAGED",
+  "status": "UNKNOWN"
+}

--- a/tests/scripts/aruba-docker.sh
+++ b/tests/scripts/aruba-docker.sh
@@ -18,7 +18,7 @@ if [[ "${TARGET_CBD_VERSION}" != "MOCK" ]]; then
 fi
 
 echo "Configure DP CLI to Server: $BASE_URL User: $USERNAME_CLI"
-DEBUG=1 dp configure --server $BASE_URL --workspace $USERNAME_CLI --apikeyid Y3JuOmFsdHVzOmlhbTp1cy13ZXN0LTE6Y2xvdWRlcmE6dXNlcjpiYmloYXJpQGhvcnRvbndvcmtzLmNvbQ== --privatekey nHkdxgZR0BaNHaSYM3ooS6rIlpV5E+k1CIkr+jFId2g=
+DEBUG=1 dp configure --server $BASE_URL --workspace $USERNAME_CLI --apikeyid Y3JuOmFsdHVzOmlhbTp1cy13ZXN0LTE6Y2xvdWRlcmE6dXNlcjphZG1pbkBleGFtcGxlLmNvbQ== --privatekey nHkdxgZR0BaNHaSYM3ooS6rIlpV5E+k1CIkr+jFId2g=
 
 echo "Running RSpec with "$CLI_TEST_FILES
 mkdir -p tmp/aruba

--- a/tests/spec/common/mock_vars.rb
+++ b/tests/spec/common/mock_vars.rb
@@ -16,5 +16,10 @@ RSpec.shared_context "mock shared vars", :a => :b do
 
     @environment_file = "../../templates/aws-environment-skeleton.json"
     @environment_crn = "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs"
+
+    @dbserver_crn = "crn:cdp:redbeams:us-west-1:hortonworks:databaseServer:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs"
+    @dbserver_name = "dbstck-mock-amazon-12345a6b7cd8e9012"
+    @dbserver_create_file = "../../templates/dbserver-create-skeleton.json"
+    @dbserver_register_file = "../../templates/dbserver-register-skeleton.json"
   }
 end

--- a/tests/spec/common/trace_response_builder.rb
+++ b/tests/spec/common/trace_response_builder.rb
@@ -68,9 +68,9 @@ class TraceResponseBuilder
         }
     end
 
-    def self.getCredentialByNameV1ResponseFactory(responseBody)
+    def self.getCredentialByNameV1ResponseFactory(responseBody, name)
         return {
-            :calledEndpoint => "#{@@base_credential_endpoint}/name/cli-aws-key",
+            :calledEndpoint => "#{@@base_credential_endpoint}/name/#{name}",
             :receivedValue => responseBody
         }
     end
@@ -91,7 +91,7 @@ class TraceResponseBuilder
 
     def self.getPrerequisitesByCloudPlatformV1ResponseFactory(cloudPlatform, responseBody)
         return {
-            :calledEndpoint => "#{@@prerequisites_endpoint}/" + cloudPlatform,
+            :calledEndpoint => [@@prerequisites_endpoint, cloudPlatform].join("/"),
             :receivedValue => responseBody
         }
     end
@@ -120,6 +120,48 @@ class TraceResponseBuilder
     def self.listDatabaseServersResponseFactory(responseBody)
         return {
             :calledEndpoint => @@base_beams_dbserver_endpoint,
+            :receivedValue => responseBody
+        }
+    end
+
+    def self.getDatabaseServerByCrnResponseFactory(responseBody, crn)
+        return {
+            :calledEndpoint => "#{@@base_beams_dbserver_endpoint}/#{crn}",
+            :receivedValue => responseBody
+        }
+    end
+
+    def self.getDatabaseServerByNameResponseFactory(responseBody, name)
+        return {
+            :calledEndpoint => "#{@@base_beams_dbserver_endpoint}/name/#{name}",
+            :receivedValue => responseBody
+        }
+    end
+
+    def self.createDatabaseServerRequestFactory(requestBody)
+        return {
+            :calledEndpoint => "#{@@base_beams_dbserver_endpoint}/managed",
+            :sentValue => requestBody
+        }
+    end
+
+    def self.releaseManagedDatabaseServerResponseFactory(responseBody, crn)
+        return {
+            :calledEndpoint => "#{@@base_beams_dbserver_endpoint}/#{crn}/release",
+            :receivedValue => responseBody
+        }
+    end
+
+    def self.registerDatabaseServerRequestFactory(requestBody)
+        return {
+            :calledEndpoint => "#{@@base_beams_dbserver_endpoint}/register",
+            :sentValue => requestBody
+        }
+    end
+
+    def self.deleteDatabaseServerByCrnResponseFactory(responseBody, crn)
+        return {
+            :calledEndpoint => "#{@@base_beams_dbserver_endpoint}/#{crn}",
             :receivedValue => responseBody
         }
     end

--- a/tests/spec/integration/credential.rb
+++ b/tests/spec/integration/credential.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Credential test cases', :type => :aruba, :feature => "Credential
   it "Credential - Describe AWS Credential", :story => "AWS Credentials", :severity => :normal, :testId => 4 do
     with_environment 'DEBUG' => '1' do
       responseHash = MockHelper.getResponseHash("../../../responses/credentials/post-aws-credential-response.json")
-      expectedEndpointResponse = TraceResponseBuilder.getCredentialByNameV1ResponseFactory(responseHash)
+      expectedEndpointResponse = TraceResponseBuilder.getCredentialByNameV1ResponseFactory(responseHash, "cli-aws-key")
       MockHelper.setupResponse("env", "getCredentialByNameV1", responseHash)
 
       result = cb.credential.describe.name("cli-aws-key").build(false)
@@ -85,7 +85,7 @@ RSpec.describe 'Credential test cases', :type => :aruba, :feature => "Credential
   it "Credential - Modify AWS Credential", :story => "AWS Credentials", :severity => :normal, :testId => 5 do
     with_environment 'DEBUG' => '1' do
       getResponseHash = MockHelper.getResponseHash("../../../responses/credentials/put-aws-credential-response.json")
-      getExpectedEndpointResponse = TraceResponseBuilder.getCredentialByNameV1ResponseFactory(getResponseHash)
+      getExpectedEndpointResponse = TraceResponseBuilder.getCredentialByNameV1ResponseFactory(getResponseHash, "cli-aws-key")
       MockHelper.setupResponse("env", "getCredentialByNameV1", getResponseHash)
 
       putResponseHash = MockHelper.getResponseHash("../../../responses/credentials/put-aws-credential-response.json")

--- a/tests/spec/integration/redbeams.rb
+++ b/tests/spec/integration/redbeams.rb
@@ -48,4 +48,96 @@ RSpec.describe 'Redbeams test cases', :type => :aruba, :feature => "Redbeams", :
       expect(MockHelper.getResponseDiff(expectedEndpointResponse, resultHash)).to be_truthy
     end
   end
+
+  it "Redbeams - Database Servers - Describe by CRN", :story => "Redbeams", :severity => :normal, :testId => 3 do
+    with_environment 'DEBUG' => '1' do
+      responseHash = MockHelper.getResponseHash("../../../responses/redbeams/dbserver.json")
+      expectedEndpointResponse = TraceResponseBuilder.getDatabaseServerByCrnResponseFactory(responseHash, @dbserver_crn)
+      MockHelper.setupResponse("beams", "getDatabaseServerByCrn", responseHash)
+
+      result = cb.redbeams.dbserver.describe.crn(@dbserver_crn).build(false)
+      resultHash = MockHelper.getResultHash(result.output)
+
+      expect(result.exit_status).to eql 0
+      expect(result.stderr.to_s.downcase).not_to include("error")
+      expect(MockHelper.getResponseDiff(expectedEndpointResponse, resultHash)).to be_truthy
+    end
+  end
+
+  it "Redbeams - Database Servers - Describe by Name", :story => "Redbeams", :severity => :normal, :testId => 4 do
+    with_environment 'DEBUG' => '1' do
+      responseHash = MockHelper.getResponseHash("../../../responses/redbeams/dbserver.json")
+      expectedEndpointResponse = TraceResponseBuilder.getDatabaseServerByNameResponseFactory(responseHash, @dbserver_name)
+      MockHelper.setupResponse("beams", "getDatabaseServerByName", responseHash)
+
+      result = cb.redbeams.dbserver.describe.env_crn(@environment_crn).name(@dbserver_name).build(false)
+      resultHash = MockHelper.getResultHash(result.output)
+
+      expect(result.exit_status).to eql 0
+      expect(result.stderr.to_s.downcase).not_to include("error")
+      expect(MockHelper.getResponseDiff(expectedEndpointResponse, resultHash)).to be_truthy
+    end
+  end
+
+  it "Redbeams - Database Servers - Create new DB Server", :story => "Redbeams", :severity => :critical, :testId => 5 do
+    with_environment 'DEBUG' => '1' do
+      responseHash = MockHelper.getResponseHash("../../../responses/redbeams/create-redbeams-response.json")
+      requestHash = MockHelper.getResponseHash("../../../requests/redbeams/create-redbeams-request.json")
+      expectedEndpointRequest = TraceResponseBuilder.createDatabaseServerRequestFactory(requestHash)
+      MockHelper.setupResponse("beams", "createDatabaseServer", responseHash)
+
+      result = cb.redbeams.dbserver.create.database_server_creation_file(@dbserver_create_file).build(true)
+      resultHash = MockHelper.getResultHash(result.output)
+
+      expect(result.exit_status).to eql 0
+      expect(result.stderr.to_s.downcase).not_to include("error")
+      expect(MockHelper.getRequestDiff("beams", expectedEndpointRequest)).to be_truthy
+    end
+  end
+
+  it "Redbeams - Database Servers - Release DB Server", :story => "Redbeams", :severity => :normal, :testId => 6 do
+    with_environment 'DEBUG' => '1' do
+      responseHash = MockHelper.getResponseHash("../../../responses/redbeams/release-redbeams-response.json")
+      expectedEndpointResponse = TraceResponseBuilder.releaseManagedDatabaseServerResponseFactory(responseHash, @dbserver_crn)
+      MockHelper.setupResponse("beams", "releaseManagedDatabaseServer", responseHash)
+
+      result = cb.redbeams.dbserver.release.crn(@dbserver_crn).build(false)
+      resultHash = MockHelper.getResultHash(result.output)
+
+      expect(result.exit_status).to eql 0
+      expect(result.stderr.to_s.downcase).not_to include("error")
+      expect(MockHelper.getResponseDiff(expectedEndpointResponse, resultHash)).to be_truthy
+    end
+  end
+
+  it "Redbeams - Database Servers - Register DB Server", :story => "Redbeams", :severity => :normal, :testId => 7 do
+    with_environment 'DEBUG' => '1' do
+      responseHash = MockHelper.getResponseHash("../../../responses/redbeams/register-redbeams-response.json")
+      requestHash = MockHelper.getResponseHash("../../../requests/redbeams/register-redbeams-request.json")
+      expectedEndpointRequest = TraceResponseBuilder.registerDatabaseServerRequestFactory(requestHash)
+      MockHelper.setupResponse("beams", "registerDatabaseServer", responseHash)
+
+      result = cb.redbeams.dbserver.register.database_server_registration_file(@dbserver_register_file).build(true)
+      resultHash = MockHelper.getResultHash(result.output)
+
+      expect(result.exit_status).to eql 0
+      expect(result.stderr.to_s.downcase).not_to include("error")
+      expect(MockHelper.getRequestDiff("beams", expectedEndpointRequest)).to be_truthy
+    end
+  end
+
+  it "Redbeams - Database Servers - Delete DB Server by CRN", :story => "Redbeams", :severity => :normal, :testId => 8 do
+    with_environment 'DEBUG' => '1' do
+      responseHash = MockHelper.getResponseHash("../../../responses/redbeams/delete-redbeams-response.json")
+      expectedEndpointResponse = TraceResponseBuilder.deleteDatabaseServerByCrnResponseFactory(responseHash, @dbserver_crn)
+      MockHelper.setupResponse("beams", "deleteDatabaseServerByCrn", responseHash)
+
+      result = cb.redbeams.dbserver.delete.crn(@dbserver_crn).build(false)
+      resultHash = MockHelper.getResultHash(result.output)
+
+      expect(result.exit_status).to eql 0
+      expect(result.stderr.to_s.downcase).not_to include("error")
+      expect(MockHelper.getResponseDiff(expectedEndpointResponse, resultHash)).to be_truthy
+    end
+  end
 end

--- a/tests/templates/dbserver-create-skeleton.json
+++ b/tests/templates/dbserver-create-skeleton.json
@@ -1,0 +1,16 @@
+{
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "databaseServer": {
+    "instanceType": "db.m3.medium",
+    "databaseVendor": "postgres",
+    "storageSize": 40,
+    "rootUserName": "dbroot",
+    "rootUserPassword": "cloudera1",
+    "aws": {
+      "backupRetentionPeriod": 1,
+      "engineVersion": "10.6"
+    },
+    "port":6789
+  },
+  "description": "auto testing"
+}

--- a/tests/templates/dbserver-register-skeleton.json
+++ b/tests/templates/dbserver-register-skeleton.json
@@ -1,0 +1,10 @@
+{
+  "connectionPassword": "dbroot",
+  "connectionUserName": "cloudera1",
+  "databaseVendor": "postgres",
+  "description": "auto testing",
+  "environmentCrn": "crn:cdp:environments:us-west-1:hortonworks:environment:a123bcde-fgh4-5i6j-7k8l-m90nop124qrs",
+  "host": "dbsvr-a12b3c4e-f5g6-78h9-iijk-lm0n1op23qr4.s5uvwxyzabcd.eu-west-1.rds.amazonaws.com",
+  "name": "dbstck-mock-amazon-12345a6b7cd8e9012",
+  "port": 5432
+}


### PR DESCRIPTION
This is the second part of our new REDBEAMS integration tests for PRs.

Now this contains all the visible DB Server commands in separate test cases.

In the next few days, based on my spare time, I'm going to write new test cases for visible DB commands.