### PR TITLE
CB-6797 - ImageV4 response should return readable creation date

### DIFF
--- a/dataplane/api-sdx/model/image_info_v4_response.go
+++ b/dataplane/api-sdx/model/image_info_v4_response.go
@@ -22,6 +22,9 @@ type ImageInfoV4Response struct {
 	// created
 	Created int64 `json:"created,omitempty"`
 
+	// date
+	Date string `json:"date,omitempty"`
+
 	// image catalog name
 	ImageCatalogName string `json:"imageCatalogName,omitempty"`
 

--- a/dataplane/api/model/image_info_v4_response.go
+++ b/dataplane/api/model/image_info_v4_response.go
@@ -22,6 +22,9 @@ type ImageInfoV4Response struct {
 	// created
 	Created int64 `json:"created,omitempty"`
 
+	// date
+	Date string `json:"date,omitempty"`
+
 	// image catalog name
 	ImageCatalogName string `json:"imageCatalogName,omitempty"`
 

--- a/dataplane/sdx/sdx.go
+++ b/dataplane/sdx/sdx.go
@@ -519,7 +519,6 @@ func SdxClusterkUpgrade(c *cli.Context) {
 		fmt.Printf("%s\n", err)
 	}
 	printResponse(resp)
-	// }
 }
 
 func createSdxUpgradeRequest(imageid string, runtime string, lockComponents bool, dryRun bool) *sdxModel.SdxUpgradeRequest {


### PR DESCRIPTION
Contains the following:

- CB-6797 - ImageV4 response should return readable creation date
- Upgraded swagger image version to v0.19.0