### PR TITLE
CB-8044 Swagger version checker need to be updated for Int Tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,6 @@
-CB_VERSION = $(shell echo \${VERSION})
-ifeq ($(CB_VERSION),)
-    	CB_VERSION ?= $(shell git describe --tags --abbrev=0)-snapshot
-endif
-GIT_ACTIVE_BRANCH ?= $(shell git rev-parse HEAD)
+CB_TARGET_BRANCH ?= $(strip $(shell git remote show origin | grep "HEAD branch" | cut -d ":" -f 2))
+CB_VERSION ?= $(shell ./scripts/get-latest-version.sh)
+GIT_ACTIVE_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 BLUEPRINT_URL ?= https://raw.githubusercontent.com/hortonworks/cb-cli/$(GIT_ACTIVE_BRANCH)/tests/blueprints/test.bp
 
 all: start-mock integration-test stop-mock clean-after-tests
@@ -23,9 +21,9 @@ deps:
 
 # Start a new Mock with new Swagger JSON
 # For custom version apply as: 'GIT_FIRST_PARENT=2.8.0-dev.374 make start-mock'
-start-mock: download-s3
+start-mock:
 	CLEANUP=true scripts/mock-test-helper.sh
-	CB_VERSION=$(CB_VERSION) tmp/cbm.sh
+	CB_TARGET_BRANCH=$(CB_TARGET_BRANCH) CB_VERSION=$(CB_VERSION) tmp/cbm.sh
 
 # Stop DataPlane Mock
 stop-mock:

--- a/tests/scripts/cbm.sh
+++ b/tests/scripts/cbm.sh
@@ -1,23 +1,113 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# -e  Exit immediately if a command exits with a non-zero status.
+# -x  Print commands and their arguments as they are executed.
 
 : ${CB_VERSION:=latest}
+: ${CB_TARGET_BRANCH:=master}
+: ${BASE_URL:=https://localhost}
 : ${STOP_MOCK:=false}
 
-set -x
+determine-versions() {
+    declare desc="Determine the MOCK version based on Swagger availability"
+
+    echo "Checking latest available MOCK for"${CB_VERSION}
+    if [[ -n "$GITHUB_TOKEN" ]]; then
+        access_token="access_token=$GITHUB_TOKEN"
+    fi
+    BRANCH_VERSION=$(echo $CB_VERSION | cut -d'-' -f1)
+    versions=($(curl https://api.github.com/repos/hortonworks/cloudbreak-deployer/git/refs/tags\?$access_token | jq -rc ".[] | select(.ref | contains(\"$BRANCH_VERSION\")) | .ref"))
+
+    if [[ -z $versions ]]; then
+        echo "Can not fetch cbd versions from github!"
+        exit 1
+    fi
+
+    for ref_ver in "${versions[@]}"
+    do
+        ver=${ref_ver#"refs/tags/"}
+        if [[ $ver < $CB_VERSION || $ver = $CB_VERSION ]]; then
+            highest_built_version=$ver
+        fi
+    done
+
+    echo "Latest available mock: $highest_built_version"
+
+    if [[ -z $highest_built_version ]]; then
+        echo "Can not determine highest built version!"
+        exit 1
+    fi
+    CB_VERSION=$highest_built_version
+}
+
+download-swagger-jsons() {
+    declare desc="Download micro services Swagger JSONs from S3 if necessary"
+
+    if [[ -z $CLOUDBREAK_ADDRESS ]]; then
+        echo "$(tput setaf 3)CLOUDBREAK_ADDRESS environment variable is not defined."
+        echo "So the swagger-${CB_VERSION}.json is going to be downloaded from S3.$(tput sgr 0)"
+
+        curl -k https://s3-eu-central-1.amazonaws.com/cloudbreak-swagger/swagger-"$CB_VERSION".json -o swagger-cloudbreak.json
+        curl -k https://s3-us-east-2.amazonaws.com/environment-swagger/swagger-"$CB_VERSION".json -o swagger-environment.json
+        curl -k https://s3-us-east-2.amazonaws.com/datalake-swagger/swagger-"$CB_VERSION".json -o swagger-datalake.json
+        curl -k https://s3-us-east-2.amazonaws.com/redbeams-swagger/swagger-"$CB_VERSION".json -o swagger-redbeams.json
+        curl -k https://s3-us-east-2.amazonaws.com/freeipa-swagger/swagger-"$CB_VERSION".json -o swagger-freeipa.json
+        curl -k https://s3-us-east-2.amazonaws.com/autoscale-swagger/swagger-"$CB_VERSION".json -o swagger-autoscale.json
+    else
+        echo "$(tput setaf 2)CLOUDBREAK_ADDRESS environment variable is defined."
+        echo "So the ${CLOUDBREAK_ADDRESS} swagger.json is supposed to already been downloaded to 'integration-tests' folder$(tput sgr 0)"
+    fi
+}
 
 get-cbd() {
     declare desc="Downloading CBD binary"
+    local os=$(uname -s)
+    local latest_tag=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=${CB_VERSION}&type=dev" | jq -r '.latest_build_version')
+    local url=$(echo "https://public-repo-1.hortonworks.com/HDP/cloudbreak/cloudbreak-deployer_${latest_tag}_${os}_x86_64.tgz")
+    local dest=.
 
-    if curl -Ls s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/cloudbreak/cloudbreak-deployer_${CB_VERSION}_$(uname)_x86_64.tgz|tar -xz cbd; then
-        echo "CBD has been found with version: $CB_VERSION"
+    if curl -Ls $url | tar -xz -C ${dest}; then
+        echo "CBD has been downloaded with version: $CB_VERSION"
     else
-        echo "Getting the latest 'snapshot' version of CBD."
-        curl -Ls s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/cloudbreak/cloudbreak-deployer_snapshot_$(uname)_x86_64.tgz|tar -xz cbd
-        echo "CBD has been found with version: $(./cbd --version)"
-    fi
+        echo "$(tput setaf 3) Building ${CB_TARGET_BRANCH} CBD for ${os}$(tput sgr 0)"
 
+        docker volume rm cbd-source 2>/dev/null || :
+        docker volume create --name cbd-source 1>/dev/null
+        docker run --rm --user="0" --entrypoint init.sh -v cbd-source:/var/workspace jpco/git:1.0 https://github.com/hortonworks/cloudbreak-deployer.git ${CB_TARGET_BRANCH} cloudbreak-deployer
+        docker run --user="0" -e GOPATH=/usr -v cbd-source:/usr/src/github.com/hortonworks -w /usr/src/github.com/hortonworks/cloudbreak-deployer golang:1.12 make bindata
+        docker run --rm --user="0" -e GOPATH=/usr -v cbd-source:/usr/src/github.com/hortonworks -w /usr/src/github.com/hortonworks/cloudbreak-deployer golang:1.12 make build
+        docker run --rm --user="0" -v cbd-source:/var/workspace jpco/git:1.0 cat /var/workspace/cloudbreak-deployer/build/${os}/cbd > cbd
+        docker volume rm cbd-source 1>/dev/null || :
+
+        chmod +x cbd
+    fi
     mkdir etc
     echo "TEST_LICENSE" > etc/license.txt
+
+    echo "CBD installed into "$(pwd)
+    echo "CBD has been found with version: $(./cbd --version)"
+}
+
+mock-start() {
+    declare desc="Start Cloudbreak Mock"
+
+    mv docker-compose.yml docker-compose-mocks.yml
+    echo "Starting CBD with minimal set:"
+    cat <<EOF > Profile
+export PUBLIC_IP=$(hostname -i)
+export CB_LOCAL_DEV_LIST=cloudbreak,periscope,datalake,freeipa,redbeams,environment,uluwatu,cluster-proxy,core-gateway
+export VAULT_AUTO_UNSEAL=true
+export COMMON_DB_VOL=mock-common
+export DOCKER_NETWORK_NAME=mock-cbreak-network
+export CB_ENABLEDPLATFORMS=AZURE,OPENSTACK,AWS,GCP,YARN,MOCK
+export ENVIRONMENT_ENABLEDPLATFORMS=AZURE,OPENSTACK,AWS,GCP,YARN,MOCK
+export UMS_HOST=''
+EOF
+    ./cbd generate
+    ./cbd start
+    ./.deps/bin/docker-compose -f docker-compose-mocks.yml -p cbreak up -d
+    echo "Mock APIs version is: " $(./cbd version)
+
+    sleep 30s
 }
 
 mock-start-logs() {
@@ -39,33 +129,9 @@ mock-start-logs() {
     fi
 }
 
-mock-start() {
-    declare desc="Start Cloudbreak Mock"
-
-    echo "Starting CBD with minimal set:"
-    mv docker-compose.yml docker-compose-mocks.yml
-
-    cat <<EOF > Profile
-export PUBLIC_IP=$(hostname -i)
-export CB_LOCAL_DEV_LIST=cloudbreak,periscope,datalake,freeipa,redbeams,environment,uluwatu,cluster-proxy,core-gateway
-export VAULT_AUTO_UNSEAL=true
-export COMMON_DB_VOL=mock-common
-export DOCKER_NETWORK_NAME=mock-cbreak-network
-export CB_ENABLEDPLATFORMS=AZURE,OPENSTACK,AWS,GCP,YARN,MOCK
-export ENVIRONMENT_ENABLEDPLATFORMS=AZURE,OPENSTACK,AWS,GCP,YARN,MOCK
-export UMS_HOST=''
-EOF
-
-    ./cbd generate
-    ./cbd start
-	./.deps/bin/docker-compose -f docker-compose-mocks.yml -p cbreak up -d
-
-    echo "Mock APIs version is: " $(./cbd version)
-
-    sleep 30s
-}
-
 mock-stop() {
+  declare desc="Stop Cloudbreak Mock"
+
 	./.deps/bin/docker-compose -f docker-compose.yml -f docker-compose-mocks.yml -p cbreak down --volumes
 	./cbd kill
 }
@@ -76,6 +142,8 @@ main() {
         mock-stop
         cd ..
     else
+        determine-versions
+        download-swagger-jsons
         get-cbd
         mock-start
         cd ..

--- a/tests/scripts/get-latest-version.sh
+++ b/tests/scripts/get-latest-version.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# -e  Exit immediately if a command exits with a non-zero status.
+# -x  Print commands and their arguments as they are executed.
+
+: ${CB_TARGET_BRANCH:=master}
+
+get-latest-version() {
+    if [[ -z $CB_VERSION ]]; then
+        if [[ $CB_TARGET_BRANCH = master* ]]; then
+            export LATEST_VERSION=$(curl "http://release.infra.cloudera.com/hwre-api/getreleaseversion?stack=CB&releaseline=master" | jq -r '.version')
+            export CB_VERSION=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=${LATEST_VERSION}&type=dev" | jq -r '.latest_build_version')
+        elif [[ $CB_TARGET_BRANCH = rc-* ]]; then
+            export BRANCH_VERSION=$(echo $CB_TARGET_BRANCH | cut -f 2 -d '-')
+            export CB_VERSION=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=${BRANCH_VERSION}.0&type=rc" | jq -r '.latest_build_version')
+        elif [[ $CB_TARGET_BRANCH = CB-* ]]; then
+            export BRANCH_VERSION=$(echo $CB_TARGET_BRANCH | cut -f 2 -d '-')
+            export CB_VERSION=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=${BRANCH_VERSION}&type=cb" | jq -r '.latest_build_version')
+        else
+            export BRANCH_VERSION=$(echo $CB_TARGET_BRANCH | cut -f 2 -d '-')
+            export CB_VERSION=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=${BRANCH_VERSION}.0" | jq -r '.latest_build_version')
+        fi
+    fi
+    echo $CB_VERSION
+}
+
+main() {
+    get-latest-version
+}
+
+main "$@"

--- a/tests/scripts/mock-test-helper.sh
+++ b/tests/scripts/mock-test-helper.sh
@@ -17,7 +17,7 @@ tmp-create() {
     declare desc="Copy all the files that needs to be modified by local Docker IP"
 
     mkdir -p tmp
-    cp -r scripts/{docker-test.sh,cbm.sh} {docker-compose.yml,swagger-*.json} {certs,responses} tmp
+    cp -r scripts/{docker-test.sh,cbm.sh} docker-compose.yml {certs,responses,requests} tmp
 }
 
 main() {


### PR DESCRIPTION
Our CB-CLI integration tests were not stable, because of:
```
CB_VERSION=2.27.0-b15 tmp/cbm.sh
curl -Ls s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/cloudbreak/cloudbreak-deployer_2.27.0-b15_Linux_x86_64.tgz
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```
We have already implemented fallback for this. However that path is getting the `2.20.0-dev.126` instead of `2.27.0-b15`:
```
Getting the latest 'snapshot' version of CBD.
curl -Ls s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/cloudbreak/cloudbreak-deployer_snapshot_Linux_x86_64.tgz
./cbd --version
echo 'CBD has been found with version: Cloudbreak Deployer: 2.20.0-dev.126-0930be3a'
CBD has been found with version: Cloudbreak Deployer: 2.20.0-dev.126-0930be3a
```
The code is still contains the old version of getting latest CBD. So we need to update this based on latest changes in versioning and tagging of Cloudbreak Deployer.