### PR TITLE
CB-14772 Fix Makefile for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ dev-debug-darwin:
 build-linux:
 	GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -a ${LDFLAGS_NOVER} -o build/Linux/${BINARY} main.go
 
+dev-debug-linux:
+	GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS_NOVER} -o ~/.local/bin/${BINARY} main.go
+
 build-windows:
 	GOOS=windows GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -a ${LDFLAGS_NOVER} -o build/Windows/${BINARY}.exe main.go
 
@@ -113,8 +116,9 @@ build-linux-version:
 build-windows-version:
 	GOOS=windows GO111MODULE=on CGO_ENABLED=0 go build -a ${LDFLAGS} -o build/Windows/${BINARY}.exe main.go
 
-install: build ## Installs OS specific binary into: /usr/local/bin
-	install build/$(shell uname -s)/$(BINARY) /usr/local/bin
+install: build ## Installs OS specific binary into: /usr/local/bin and ~/.local/bin
+	install build/$(shell uname -s)/$(BINARY) /usr/local/bin || true
+	install build/$(shell uname -s)/$(BINARY) ~/.local/bin || true
 
 _init-swagger-generation:
 	rm -rf dataplane/api/client dataplane/api/model


### PR DESCRIPTION
* Fix `Makefile` target `install` to succeed in Linux deployments. Whereas Mac permits installing binaries to directory `/usr/local/bin` even for non-`root` users, Linux prohibits this. In order to avoid having to run the command as `root`, the compiled binary will be also copied to directory `~/.local/bin` that usually exists in Linux in the user home.
  * `~/.local/bin` is not explicitly created. This is the user's responsibility, and so is adding that directory to `PATH`.
  * Copy operations will be attempted for both locations, no matter which OS is being used. A failure of either copy will not make the target `install` fail.
* Add new `Makefile` target `dev-debug-linux` in analogy with `dev-debug-darwin`. Besides the different platform, this target will output the compiled binary to directory `~/.local/bin` .